### PR TITLE
updated ARIA for drawer items

### DIFF
--- a/templates/pageLevelProgress.hbs
+++ b/templates/pageLevelProgress.hbs
@@ -1,12 +1,12 @@
-<div class="page-level-progress-inner">
+<div class="page-level-progress-inner" role="progressbar">
     {{#each components}}
     <div class="page-level-progress-item drawer-item">
         {{#if _isVisible}}
-        <a class="page-level-progress-item-title clearfix drawer-item-open" href="#" data-page-level-progress-id="{{_id}}">
+        <a class="page-level-progress-item-title clearfix drawer-item-open" href="#" data-page-level-progress-id="{{_id}}"  aria-label="{{{title}}}">
         {{else}}
         <div class="page-level-progress-item-title drawer-item-open disabled clearfix">
         {{/if}}
-        	<h5 class="page-level-progress-item-title-inner">
+            <h5 class="page-level-progress-item-title-inner">
             {{{title}}}
             </h5>
             <div class="page-level-progress-indicator page-level-progress-indicator-{{#if _isComplete}}complete{{else}}incomplete{{/if}}">


### PR DESCRIPTION
fixed issue/#27

- JAWS auto reads drawer item titles so blind users can navigate to set components.