### PR TITLE
Unified completion calculation and added _isOptional support

### DIFF
--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -2,6 +2,7 @@ define(function(require) {
 
     var Adapt = require('coreJS/adapt');
     var Backbone = require('backbone');
+    var util = require('./util');
 
     var PageLevelProgressView = require('extensions/adapt-contrib-pageLevelProgress/js/PageLevelProgressView');
 
@@ -41,16 +42,16 @@ define(function(require) {
         },
 
         updateProgressBar: function() {
-            var componentCompletionRatio = this.collection.where({_isComplete: true}).length / this.collection.length;
-            var percentageOfCompleteComponents = componentCompletionRatio * 100;
+            var completionObject = util.calculateCompletion(this.model);
+            var percentageComplete = Math.floor((completionObject.completed / completionObject.total)*100);
 
-            this.$('.page-level-progress-navigation-bar').css('width', percentageOfCompleteComponents + '%');
+            this.$('.page-level-progress-navigation-bar').css('width', percentageComplete + '%');
 
             // Add percentage of completed components as an aria label attribute
-            this.$el.attr('aria-label', this.ariaText +  Math.floor(percentageOfCompleteComponents) + '%');
+            this.$el.attr('aria-label', this.ariaText +  percentageComplete + '%');
 
             // Set percentage of completed components to model attribute to update progress on MenuView
-            this.model.set('completedChildrenAsPercentage', percentageOfCompleteComponents);
+            this.model.set('completedChildrenAsPercentage', percentageComplete);
         },
 
         onProgressClicked: function(event) {

--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -7,65 +7,21 @@ define(function(require) {
 
     var Adapt = require('coreJS/adapt');
     var Backbone = require('backbone');
+    var util = require('./util');
 
     var PageLevelProgressMenuView = require('extensions/adapt-contrib-pageLevelProgress/js/PageLevelProgressMenuView');
     var PageLevelProgressNavigationView = require('extensions/adapt-contrib-pageLevelProgress/js/PageLevelProgressNavigationView');
 
     function setupPageLevelProgress(pageModel, enabledProgressComponents) {
 
-        var componentsCollection = new Backbone.Collection(enabledProgressComponents);
+        new PageLevelProgressNavigationView({model: pageModel, collection:  new Backbone.Collection(enabledProgressComponents) });
 
-        new PageLevelProgressNavigationView({model: pageModel, collection: componentsCollection});
-
-    }
-
-    // To get only those models who were enabled for pageLevelProgress
-    function getPageLevelProgressEnabledModels(models) {
-        return _.filter(models, function(model) {
-            if (model.get('_pageLevelProgress')) {
-                return model.get('_pageLevelProgress')._isEnabled;
-            }
-        });
-    }
-
-    // Calculate completion of a contentObject
-    function calculateCompletion(contentObjectModel) {
-
-        var viewType = contentObjectModel.get('_type'),
-            totalComponentsEnabled = 0,
-            totalComponentsCompleted = 0;
-
-        // If it's a page
-        if (viewType == 'page') {
-            var children = contentObjectModel.findDescendants('components').where({'_isAvailable': true});
-            var components = getPageLevelProgressEnabledModels(children);
-
-            totalComponentsEnabled = components.length | 0,
-            totalComponentsCompleted = _.filter(components, function(item) {
-                return item.get('_isComplete');
-            }).length;
-
-            return {
-                "completed": totalComponentsCompleted,
-                "total": totalComponentsEnabled
-            };
-        }
-        // If it's a sub-menu
-        else if (viewType == 'menu' && contentObjectModel.get('_id') != Adapt.location._currentId) {
-            _.each(contentObjectModel.get('_children').models, function(contentObject) {
-                var completionObject = calculateCompletion(contentObject);
-                totalComponentsEnabled += completionObject.total;
-                totalComponentsCompleted += completionObject.completed;
-            });
-            return {
-                "completed": totalComponentsCompleted,
-                "total": totalComponentsEnabled
-            };
-        }
     }
 
     // This should add/update progress on menuView
     Adapt.on('menuView:postRender', function(view) {
+
+        if (view.model.get('_id') == Adapt.location._currentId) return;
 
         // do not proceed until pageLevelProgress enabled on course.json
         if (!Adapt.course.get('_pageLevelProgress') || !Adapt.course.get('_pageLevelProgress')._isEnabled) {
@@ -80,7 +36,7 @@ define(function(require) {
 
         if (pageLevelProgress && pageLevelProgress._isEnabled) {
 
-            var completionObject = calculateCompletion(view.model);
+            var completionObject = util.calculateCompletion(view.model);
             var percentageComplete = (completionObject.completed / completionObject.total)*100;
             view.model.set('completedChildrenAsPercentage', percentageComplete);
             view.$el.find('.menu-item-inner').append(new PageLevelProgressMenuView({model: view.model}).$el);
@@ -98,7 +54,7 @@ define(function(require) {
         }
 
         var currentPageComponents = pageModel.findDescendants('components').where({'_isAvailable': true});
-        var enabledProgressComponents = getPageLevelProgressEnabledModels(currentPageComponents);
+        var enabledProgressComponents = util.getPageLevelProgressEnabledModels(currentPageComponents);
 
         if (enabledProgressComponents.length > 0) {
             setupPageLevelProgress(pageModel, enabledProgressComponents);

--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -37,7 +37,7 @@ define(function(require) {
         if (pageLevelProgress && pageLevelProgress._isEnabled) {
 
             var completionObject = util.calculateCompletion(view.model);
-            var percentageComplete = (completionObject.completed / completionObject.total)*100;
+            var percentageComplete = Math.floor((completionObject.completed / completionObject.total)*100);
             view.model.set('completedChildrenAsPercentage', percentageComplete);
             view.$el.find('.menu-item-inner').append(new PageLevelProgressMenuView({model: view.model}).$el);
 

--- a/js/util.js
+++ b/js/util.js
@@ -1,0 +1,58 @@
+/*
+ * adapt-contrib-pageLevelProgress
+ * License - http://github.com/adaptlearning/adapt_framework/blob/master/LICENSE
+ * Maintainers - Daryl Hedley <darylhedley@hotmail.com>, Himanshu Rajotia <himanshu.rajotia@exultcorp.com>, "Oliver Foster" <oliver.foser@kineo.com>
+ */
+define(function() {
+    
+    // Calculate completion of a contentObject
+    function calculateCompletion(contentObjectModel) {
+
+        var viewType = contentObjectModel.get('_type'),
+            totalComponentsEnabled = 0,
+            totalComponentsCompleted = 0;
+
+        // If it's a page
+        if (viewType == 'page') {
+            var children = contentObjectModel.findDescendants('components').where({'_isAvailable': true, '_isOptional': false});
+            var components = getPageLevelProgressEnabledModels(children);
+
+            totalComponentsEnabled = components.length | 0,
+            totalComponentsCompleted = _.filter(components, function(item) {
+                return item.get('_isComplete');
+            }).length;
+
+            return {
+                "completed": totalComponentsCompleted,
+                "total": totalComponentsEnabled
+            };
+        }
+        // If it's a sub-menu
+        else if (viewType == 'menu') {
+            _.each(contentObjectModel.get('_children').models, function(contentObject) {
+                var completionObject = calculateCompletion(contentObject);
+                totalComponentsEnabled += completionObject.total;
+                totalComponentsCompleted += completionObject.completed;
+            });
+            return {
+                "completed": totalComponentsCompleted,
+                "total": totalComponentsEnabled
+            };
+        }
+    }
+
+    //Get only those models who were enabled for pageLevelProgress
+    function getPageLevelProgressEnabledModels(models) {
+        return _.filter(models, function(model) {
+            if (model.get('_pageLevelProgress')) {
+                return model.get('_pageLevelProgress')._isEnabled;
+            }
+        });
+    }
+
+    return {
+    	calculateCompletion: calculateCompletion,
+    	getPageLevelProgressEnabledModels: getPageLevelProgressEnabledModels
+    };
+
+})

--- a/less/pageLevelProgress.less
+++ b/less/pageLevelProgress.less
@@ -37,6 +37,11 @@
     width:80%;
 }
 
+.page-level-progress-item-optional-text {
+    line-height: 1em;
+    text-align: right;
+}
+
 .page-level-progress-indicator {
     width: 16%;
     height: 10px;

--- a/templates/pageLevelProgress.hbs
+++ b/templates/pageLevelProgress.hbs
@@ -10,10 +10,23 @@
             <div class="page-level-progress-item-title-inner accessible-text-block h5">
             {{{title}}}
             </div>
-            <div class="page-level-progress-indicator page-level-progress-indicator-{{#if _isComplete}}complete{{else}}incomplete{{/if}}">
-                <div class="page-level-progress-indicator-bar">
+            {{#if _isComplete}}
+                <div class="page-level-progress-indicator page-level-progress-indicator-{{#if _isComplete}}complete{{else}}incomplete{{/if}}">
+                    <div class="page-level-progress-indicator-bar">
+                    </div>
                 </div>
-            </div>
+            {{else}}
+                {{#if _isOptional}}
+                    <div class="page-level-progress-item-optional-text">
+                    {{_globals._extensions._pageLevelProgress.optionalContent}}
+                    </div>
+                {{else}}
+                    <div class="page-level-progress-indicator page-level-progress-indicator-{{#if _isComplete}}complete{{else}}incomplete{{/if}}">
+                        <div class="page-level-progress-indicator-bar">
+                        </div>
+                    </div>
+                {{/if}}
+            {{/if}}
         {{#if _isVisible}}
         </a>
         {{else}}


### PR DESCRIPTION
In the drawer:
  Added 'Optional Content' text instead of tablet as per request from designer.
  'Optional Content' text becomes a full tablet once complete.

On the menu and page:
  Excluded _isOptional components from the completion calculation