### PR TITLE
Move globals to _globals._extensions

### DIFF
--- a/js/PageLevelProgressMenuView.js
+++ b/js/PageLevelProgressMenuView.js
@@ -11,7 +11,7 @@ define(function(require) {
             this.listenTo(Adapt, 'remove', this.remove);
 
             this.ariaText = '';
-            if (Adapt.course.get('_globals')._extensions && Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar) {
+            if (Adapt.course.get('_globals')._extensions && Adapt.course.get('_globals')._extensions._pageLevelProgress && Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar) {
                 this.ariaText = Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar + ' ';
             }
 

--- a/js/PageLevelProgressMenuView.js
+++ b/js/PageLevelProgressMenuView.js
@@ -11,7 +11,7 @@ define(function(require) {
             this.listenTo(Adapt, 'remove', this.remove);
 
             this.ariaText = '';
-            if (Adapt.course.get('_globals')._accessibility && Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar) {
+            if (Adapt.course.get('_globals')._extensions && Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar) {
                 this.ariaText = Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar + ' ';
             }
 

--- a/js/PageLevelProgressMenuView.js
+++ b/js/PageLevelProgressMenuView.js
@@ -11,8 +11,8 @@ define(function(require) {
             this.listenTo(Adapt, 'remove', this.remove);
 
             this.ariaText = '';
-            if (Adapt.course.get('_globals')._accessibility && Adapt.course.get('_globals')._accessibility._ariaLabels.pageLevelProgressIndicatorBar) {
-                this.ariaText = Adapt.course.get('_globals')._accessibility._ariaLabels.pageLevelProgressIndicatorBar + ' ';
+            if (Adapt.course.get('_globals')._accessibility && Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar) {
+                this.ariaText = Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar + ' ';
             }
 
             this.render();

--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -19,7 +19,7 @@ define(function(require) {
             this.$el.attr('href', '#');
             this.$el.attr('role', 'button');
             this.ariaText = '';
-            if (Adapt.course.get('_globals')._extensions && Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar) {
+            if (Adapt.course.get('_globals')._extensions && Adapt.course.get('_globals')._extensions._pageLevelProgress && Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar) {
                 this.ariaText =Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar +  ' ';
             }
             this.render();

--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -19,7 +19,7 @@ define(function(require) {
             this.$el.attr('href', '#');
             this.$el.attr('role', 'button');
             this.ariaText = '';
-            if (Adapt.course.get('_globals')._accessibility && Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar) {
+            if (Adapt.course.get('_globals')._extensions && Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar) {
                 this.ariaText =Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar +  ' ';
             }
             this.render();

--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -19,8 +19,8 @@ define(function(require) {
             this.$el.attr('href', '#');
             this.$el.attr('role', 'button');
             this.ariaText = '';
-            if (Adapt.course.get('_globals')._accessibility && Adapt.course.get('_globals')._accessibility._ariaLabels.pageLevelProgressIndicatorBar) {
-                this.ariaText =Adapt.course.get('_globals')._accessibility._ariaLabels.pageLevelProgressIndicatorBar +  ' ';
+            if (Adapt.course.get('_globals')._accessibility && Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar) {
+                this.ariaText =Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar +  ' ';
             }
             this.render();
             _.defer(_.bind(function() {

--- a/properties.schema
+++ b/properties.schema
@@ -3,6 +3,29 @@
   "$schema": "http://json-schema.org/draft-04/schema",
   "id": "http://jsonschema.net",
   "required":false,
+  "globals": {
+    "pageLevelProgress": {
+      "type": "string",
+      "required": true,
+      "default": "Page sections",
+      "inputType": "Text",
+      "validators": []
+    },
+    "pageLevelProgressIndicatorBar": {
+      "type": "string",
+      "required": true,
+      "default": "You have completed ",
+      "inputType": "Text",
+      "validators": []
+    },
+    "pageLevelProgressEnd": {
+      "type": "string",
+      "required": true,
+      "default": "You have reached the end of the list of page sections.",
+      "inputType": "Text",
+      "validators": []
+    }
+  },
   "properties":{
     "pluginLocations": {
       "type":"object",


### PR DESCRIPTION
Also see https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/pull/59.

_globals._accessibility._ariaLabels.complete and _globals._accessibility._ariaLabels.incomplete are used by PLP and adapt-contrib-vanilla/templates/partials/state.hbs


_globals._accessibility._ariaLabels.locked only seems to be used by PLP although it's probably quite generic.