### PR TITLE
hotfix/pageCompletionListener

### DIFF
--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -16,6 +16,7 @@ define(function(require) {
             this.listenTo(Adapt, 'remove', this.remove);
             this.listenTo(Adapt, 'router:location', this.updateProgressBar);
             this.listenTo(this.collection, 'change:_isInteractionComplete', this.updateProgressBar);
+            this.listenTo(this.model, 'change:_isInteractionComplete', this.updateProgressBar);
             this.$el.attr('href', '#');
             this.$el.attr('role', 'button');
             this.ariaText = '';


### PR DESCRIPTION
As the page completion now forms a part of the page's navigation progress bar (as a way of allowing non-plp, non-optional components to count as part of the completion). The page progress bar should listen to the page completion.