### PR TITLE
Add missing optionalContent

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -24,6 +24,13 @@
       "default": "You have reached the end of the list of page sections.",
       "inputType": "Text",
       "validators": []
+    },
+    "optionalContent": {
+      "type": "string",
+      "required": true,
+      "default": "Optional Content",
+      "inputType": "Text",
+      "validators": []
     }
   },
   "properties":{


### PR DESCRIPTION
Global aria label for optional content that is displayed in PLP, was missing from the properties.schema