### PR TITLE
pageLevelProgress - add box-sizing to disabled item

### DIFF
--- a/less/pageLevelProgress.less
+++ b/less/pageLevelProgress.less
@@ -6,6 +6,7 @@
         padding:@item-padding;
         display:block;
         &.drawer-item-open.disabled {
+            box-sizing:border-box;
             background-color:@item-color-disabled;
             color:@item-text-color-disabled;
             .no-touch &:hover {


### PR DESCRIPTION
pageLevelProgress.hbs uses <button> for enabled items and <div> for disabled items. When Trickle is deployed, locked items are disabled and do not display properly in the drawer: 

![before-box-sizing](https://cloud.githubusercontent.com/assets/9489014/12707239/13d315e8-c857-11e5-8f54-d86e9feb2347.gif)

Divs differ from buttons in box-sizing. Setting the div's box-sizing to border-box in order to match buttons eliminates the issue:

![after-box-sizing](https://cloud.githubusercontent.com/assets/9489014/12707265/71c056d4-c857-11e5-947e-64502b0d9526.gif)

------------------
There remains a noticeable difference in how the texts are styled, but I'll raise that in a separate issue. 