### PR TITLE
Issue-1138

### DIFF
--- a/js/completionCalculations.js
+++ b/js/completionCalculations.js
@@ -45,11 +45,10 @@ define([
 
             if (contentObjectModel.get("_pageLevelProgress") && contentObjectModel.get("_pageLevelProgress")._showPageCompletion !== false 
                 && Adapt.course.get("_pageLevelProgress") && Adapt.course.get("_pageLevelProgress")._showPageCompletion !== false) {
-                //optioanlly add one point extra for page completion to eliminate incomplete pages and full progress bars
+                //optionally add one point extra for page completion to eliminate incomplete pages and full progress bars
+                // if _showPageCompletion is true then the progress bar should also consider it so add 1 to nonAssessmentTotal
                 pageCompletion.nonAssessmentCompleted += isComplete;
                 pageCompletion.nonAssessmentTotal += 1;
-                pageCompletion.assessmentCompleted += isComplete;
-                pageCompletion.assessmentTotal += 1;
             }
 
             return pageCompletion;


### PR DESCRIPTION
if _showPageCompletion is true then we need to consider it in the progress bar. The code was adding 1 to both nonAssessmentCompleted and assessmentCompleted, which meant the progress bar considered the page twice. This left the bar looking very uneven when at the point of waiting for completion of the final component.
