### PR TITLE
correct reference to non-existent variable 'children'

### DIFF
--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -50,7 +50,7 @@ define(function(require) {
         
         refreshProgressBar: function() {
             var currentPageComponents = this.model.findDescendants('components').where({'_isAvailable': true});
-            var availableChildren = completionCalculations.filterAvailableChildren(children);
+            var availableChildren = completionCalculations.filterAvailableChildren(currentPageComponents);
             var enabledProgressComponents = completionCalculations.getPageLevelProgressEnabledModels(availableChildren);
             
             this.collection = new Backbone.Collection(enabledProgressComponents);


### PR DESCRIPTION
replacing it with `currentPageComponents`

see https://github.com/adaptlearning/adapt_framework/issues/1146

version bump shouldn't be required as that's already been done in #89 