### PR TITLE
Article titles appear in the PLP list

### DIFF
--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -37,9 +37,8 @@ define(function(require) {
         },
 
         render: function() {
-            var components = this.collection.toJSON();
             var data = {
-                components: components,
+                collection: this.collection.toJSON(),
                 _globals: Adapt.course.get('_globals')
             };            
 

--- a/js/PageLevelProgressView.js
+++ b/js/PageLevelProgressView.js
@@ -27,9 +27,8 @@ define(function(require) {
         },
 
         render: function() {
-            var components = this.collection.toJSON();
             var data = {
-                components: components,
+                items: this.collection.toJSON(),
                 _globals: Adapt.course.get('_globals')
             };
             var template = Handlebars.templates['pageLevelProgress'];

--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -8,7 +8,7 @@ define(function(require) {
     var PageLevelProgressNavigationView = require('extensions/adapt-contrib-pageLevelProgress/js/PageLevelProgressNavigationView');
 
     function setupPageLevelProgress(pageModel, plpList) {
-        new PageLevelProgressNavigationView({model: pageModel, collection: new Backbone.Collection(enabledProgressComponents)});
+        new PageLevelProgressNavigationView({model: pageModel, collection: new Backbone.Collection(plpList)});
     }
 
     // This should add/update progress on menuView

--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -7,7 +7,7 @@ define(function(require) {
     var PageLevelProgressMenuView = require('extensions/adapt-contrib-pageLevelProgress/js/PageLevelProgressMenuView');
     var PageLevelProgressNavigationView = require('extensions/adapt-contrib-pageLevelProgress/js/PageLevelProgressNavigationView');
 
-    function setupPageLevelProgress(pageModel, enabledProgressComponents) {
+    function setupPageLevelProgress(pageModel, plpList) {
         new PageLevelProgressNavigationView({model: pageModel, collection: new Backbone.Collection(enabledProgressComponents)});
     }
 
@@ -33,12 +33,12 @@ define(function(require) {
 
             //take all non-assessment components and subprogress info into the percentage
             //this allows the user to see if the assessments are passed (subprogress) and all other components are complete
-            
+
             var completed = completionObject.nonAssessmentCompleted + completionObject.subProgressCompleted;
             var total = completionObject.nonAssessmentTotal + completionObject.subProgressTotal;
 
             var percentageComplete = Math.floor((completed / total) * 100);
-            
+
             view.model.set('completedChildrenAsPercentage', percentageComplete);
             view.$el.find('.menu-item-inner').append(new PageLevelProgressMenuView({model: view.model}).$el);
         }
@@ -58,10 +58,13 @@ define(function(require) {
             return comp.get('_isAvailable') === true;
         });
         var availableComponents = completionCalculations.filterAvailableChildren(currentPageComponents);
-        var enabledProgressComponents = completionCalculations.getPageLevelProgressEnabledModels(availableComponents);
+        var plpList = completionCalculations.getPageLevelProgressEnabledModels(availableComponents);
+        if (Adapt.course.get('_pageLevelProgress')._showArticleTitles) {
+        plpList = completionCalculations.generateListWithTitles(pageModel.findDescendants('articles').models, plpList);
+        }
 
-        if (enabledProgressComponents.length > 0) {
-            setupPageLevelProgress(pageModel, enabledProgressComponents);
+        if (plpList.length > 0) {
+            setupPageLevelProgress(pageModel, plpList);
         }
     });
 

--- a/js/completionCalculations.js
+++ b/js/completionCalculations.js
@@ -1,7 +1,7 @@
 define([
     'coreJS/adapt'
 ], function(Adapt) {
-    
+
     // Calculate completion of a contentObject
     function calculateCompletion(contentObjectModel) {
 
@@ -45,7 +45,7 @@ define([
                 "assessmentTotal": assessmentComponentsTotal
             };
 
-            if (contentObjectModel.get("_pageLevelProgress") && contentObjectModel.get("_pageLevelProgress")._showPageCompletion !== false 
+            if (contentObjectModel.get("_pageLevelProgress") && contentObjectModel.get("_pageLevelProgress")._showPageCompletion !== false
                 && Adapt.course.get("_pageLevelProgress") && Adapt.course.get("_pageLevelProgress")._showPageCompletion !== false) {
                 //optionally add one point extra for page completion to eliminate incomplete pages and full progress bars
                 // if _showPageCompletion is true then the progress bar should also consider it so add 1 to nonAssessmentTotal
@@ -123,6 +123,21 @@ define([
         }
     }
 
+    function generateListWithTitles(articleModels, componentModels) {
+      var articleCount = 0;
+      var contentsList = [];
+      contentsList.push(articleModels[articleCount]);
+      for (var components in componentModels) {
+        var componentArticle = componentModels[components].getParent().getParent();
+        if(componentArticle != articleModels[articleCount]) {
+          articleCount++;
+          contentsList.push(articleModels[articleCount]);
+        }
+        contentsList.push(componentModels[components]);
+      }
+      return contentsList;
+    }
+
     function filterAvailableChildren(children) {
         var availableChildren = [];
 
@@ -139,7 +154,8 @@ define([
     return {
     	calculateCompletion: calculateCompletion,
     	getPageLevelProgressEnabledModels: getPageLevelProgressEnabledModels,
-        filterAvailableChildren: filterAvailableChildren
+        filterAvailableChildren: filterAvailableChildren,
+        generateListWithTitles: generateListWithTitles
     };
 
 })

--- a/less/pageLevelProgress.less
+++ b/less/pageLevelProgress.less
@@ -27,6 +27,9 @@
                 }
             }
         }
+        &.page-level-progress-item-article {
+          text-align: center;
+        }
     }
 }
 

--- a/templates/pageLevelProgress.hbs
+++ b/templates/pageLevelProgress.hbs
@@ -1,6 +1,6 @@
 <div class="page-level-progress-inner" role="region" aria-label="{{_globals._extensions._pageLevelProgress.pageLevelProgress}}" {{#if _globals._extensions._pageLevelProgress.pageLevelProgress}}tabindex="0"{{/if}}>
     <div role="list">
-    {{#each components}}
+    {{#each items}}
         {{#if _isPartOfAssessment}}
             <div role="listitem" class="page-level-progress-item drawer-item">
                 {{#if _isVisible}}
@@ -38,7 +38,7 @@
         {{else}}
             <div role="listitem" class="page-level-progress-item drawer-item">
                 {{#if _isVisible}}
-                <button class="base page-level-progress-item-title clearfix drawer-item-open" tabindex="0" role="button" data-page-level-progress-id="{{_id}}" aria-label="{{title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}">
+                <button class="base page-level-progress-item-title {{#equals _type 'article'}}page-level-progress-item-article{{/equals}} clearfix drawer-item-open" tabindex="0" role="button" data-page-level-progress-id="{{_id}}" aria-label="{{title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}">
                 {{else}}
                 <div class="page-level-progress-item-title drawer-item-open disabled clearfix">
                     <span class="aria-label prevent-default" tabindex="0" role="button">{{_globals._accessibility._ariaLabels.locked}}. {{title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}</span>
@@ -46,6 +46,7 @@
                     <div class="page-level-progress-item-title-inner accessible-text-block h5">
                     {{{title}}}
                     </div>
+                    {{#equals _type 'component'}}
                     {{#if _isComplete}}
                         <div class="page-level-progress-indicator page-level-progress-indicator-{{#if _isComplete}}complete{{else}}incomplete{{/if}}">
                             <div class="page-level-progress-indicator-bar">
@@ -63,6 +64,7 @@
                             </div>
                         {{/if}}
                     {{/if}}
+                  {{/equals}}
                 {{#if _isVisible}}
                 </button>
                 {{else}}


### PR DESCRIPTION
https://github.com/adaptlearning/adapt_framework/issues/869

Adds articles titles into the Page Level Progress bar too. Implemented as a single attribute on the course level that enables all the articles in the course (as this was a more popular implementation for our team) but happy to change to be more granular at the article level.