### PR TITLE
update the template so it can compile handlebars expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Several elements of **Page Level Progress** have been assigned a label using the
 No known limitations.  
 
 ----------------------------
-**Version number:**  2.0.9   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Version number:**  2.0.10   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
 **Framework versions:**  2.2+     
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/graphs/contributors)    
 **Accessibility support:** WAI AA   

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "adapt-contrib-pageLevelProgress",
-    "version": "2.0.9",
+    "version": "2.0.10",
     "framework": ">=2.2.0",
     "homepage": "https://github.com/adaptlearning/adapt-contrib-pageLevelProgress",
     "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-pageLevelProgress%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",

--- a/templates/pageLevelProgress.hbs
+++ b/templates/pageLevelProgress.hbs
@@ -1,16 +1,18 @@
+{{! make the _globals object in course.json available to this template}}
+{{import_globals}}
 <div class="page-level-progress-inner" role="region" aria-label="{{_globals._extensions._pageLevelProgress.pageLevelProgress}}" {{#if _globals._extensions._pageLevelProgress.pageLevelProgress}}tabindex="0"{{/if}}>
     <div role="list">
     {{#each components}}
         {{#if _isPartOfAssessment}}
             <div role="listitem" class="page-level-progress-item drawer-item">
                 {{#if _isVisible}}
-                <button class="base page-level-progress-item-title clearfix drawer-item-open" tabindex="0" role="button" data-page-level-progress-id="{{_id}}" aria-label="{{title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}">
+                <button class="base page-level-progress-item-title clearfix drawer-item-open" tabindex="0" role="button" data-page-level-progress-id="{{_id}}" aria-label="{{compile title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}">
                 {{else}}
                 <div class="page-level-progress-item-title drawer-item-open disabled clearfix">
-                    <span class="aria-label prevent-default" tabindex="0" role="button">{{_globals._accessibility._ariaLabels.locked}}. {{title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}</span>
+                    <span class="aria-label prevent-default" tabindex="0" role="button">{{_globals._accessibility._ariaLabels.locked}}. {{compile title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}</span>
                 {{/if}}
-                    <div class="page-level-progress-item-title-inner h5">
-                    {{{title}}}
+                    <div class="page-level-progress-item-title-inner accessible-text-block h5">
+                    {{{compile title}}}
                     </div>
                     {{#if _isComplete}}
                         <div class="page-level-progress-indicator page-level-progress-indicator-complete">
@@ -38,13 +40,13 @@
         {{else}}
             <div role="listitem" class="page-level-progress-item drawer-item">
                 {{#if _isVisible}}
-                <button class="base page-level-progress-item-title clearfix drawer-item-open" tabindex="0" role="button" data-page-level-progress-id="{{_id}}" aria-label="{{title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}">
+                <button class="base page-level-progress-item-title clearfix drawer-item-open" tabindex="0" role="button" data-page-level-progress-id="{{_id}}" aria-label="{{compile title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}">
                 {{else}}
                 <div class="page-level-progress-item-title drawer-item-open disabled clearfix">
-                    <span class="aria-label prevent-default" tabindex="0" role="button">{{_globals._accessibility._ariaLabels.locked}}. {{title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}</span>
+                    <span class="aria-label prevent-default" tabindex="0" role="button">{{_globals._accessibility._ariaLabels.locked}}. {{compile title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}</span>
                 {{/if}}
-                    <div class="page-level-progress-item-title-inner h5">
-                    {{{title}}}
+                    <div class="page-level-progress-item-title-inner accessible-text-block h5">
+                    {{{compile title}}}
                     </div>
                     {{#if _isComplete}}
                         <div class="page-level-progress-indicator page-level-progress-indicator-{{#if _isComplete}}complete{{else}}incomplete{{/if}}">


### PR DESCRIPTION
if used in the component `title`. 

Useful if you wanted to do something like have a randomised assessment where the question titles are 'Question 1', 'Question 2' etc. this would allow you to do that by including a handlebars helper to calculate the question number that could then be compiled into the component title e.g. "Question {{questionNumber}}"

Fixes https://github.com/adaptlearning/adapt_framework/issues/1879