### PR TITLE
accessibility: issue/#2075 and issue/#2165

### DIFF
--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -24,8 +24,6 @@ define([
             this.listenTo(this.collection, 'change:_isComplete', this.updateProgressBar);
             this.listenTo(this.model, 'change:_isComplete', this.updateProgressBar);
 
-            this.$el.attr('role', 'button');
-
             this.ariaText = Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar +  ' ';
 
             this.render();

--- a/properties.schema
+++ b/properties.schema
@@ -7,7 +7,7 @@
     "pageLevelProgress": {
       "type": "string",
       "required": true,
-      "default": "Page sections",
+      "default": "Page regions",
       "inputType": "Text",
       "validators": [],
       "translatable": true
@@ -15,7 +15,7 @@
     "pageLevelProgressIndicatorBar": {
       "type": "string",
       "required": true,
-      "default": "Progress bar. Select here to view your current progress, and select an item to navigate to it. You have completed ",
+      "default": "Page progress. Use this to listen to the list of regions in this topic and whether they're completed. You can jump directly to any that are incomplete or which sound particularly interesting.",
       "inputType": "Text",
       "validators": [],
       "translatable": true
@@ -23,7 +23,7 @@
     "pageLevelProgressMenuBar": {
       "type": "string",
       "required": true,
-      "default": "You have completed ",
+      "default": "Page completed ",
       "inputType": "Text",
       "validators": [],
       "translatable": true
@@ -31,7 +31,7 @@
     "optionalContent": {
       "type": "string",
       "required": true,
-      "default": "Optional Content",
+      "default": "Optional content",
       "inputType": "Text",
       "validators": [],
       "translatable": true

--- a/properties.schema
+++ b/properties.schema
@@ -28,14 +28,6 @@
       "validators": [],
       "translatable": true
     },
-    "pageLevelProgressEnd": {
-      "type": "string",
-      "required": true,
-      "default": "You have reached the end of the list of page sections.",
-      "inputType": "Text",
-      "validators": [],
-      "translatable": true
-    },
     "optionalContent": {
       "type": "string",
       "required": true,

--- a/templates/pageLevelProgress.hbs
+++ b/templates/pageLevelProgress.hbs
@@ -1,12 +1,13 @@
 {{! make the _globals object in course.json available to this template}}
 {{import_globals}}
-<div class="page-level-progress-inner" role="region" aria-label="{{_globals._extensions._pageLevelProgress.pageLevelProgress}}" {{#if _globals._extensions._pageLevelProgress.pageLevelProgress}}tabindex="0"{{/if}}>
+<div class="page-level-progress-inner">
+    {{a11y_aria_label _globals._extensions._pageLevelProgress.pageLevelProgress}}
     <div role="list">
     {{#each components}}
         {{#if _isPartOfAssessment}}
             <div role="listitem" class="page-level-progress-item drawer-item">
                 {{#if _isVisible}}
-                <button class="base page-level-progress-item-title clearfix drawer-item-open" tabindex="0" role="button" data-page-level-progress-id="{{_id}}" aria-label="{{compile title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}">
+                <button class="base page-level-progress-item-title clearfix drawer-item-open" data-page-level-progress-id="{{_id}}" aria-label="{{compile title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}">
                 {{else}}
                 <div class="page-level-progress-item-title drawer-item-open disabled clearfix">
                     <span class="aria-label prevent-default" tabindex="0" role="button">{{_globals._accessibility._ariaLabels.locked}}. {{compile title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}</span>
@@ -40,7 +41,7 @@
         {{else}}
             <div role="listitem" class="page-level-progress-item drawer-item">
                 {{#if _isVisible}}
-                <button class="base page-level-progress-item-title clearfix drawer-item-open" tabindex="0" role="button" data-page-level-progress-id="{{_id}}" aria-label="{{compile title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}">
+                <button class="base page-level-progress-item-title clearfix drawer-item-open" data-page-level-progress-id="{{_id}}" aria-label="{{compile title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}">
                 {{else}}
                 <div class="page-level-progress-item-title drawer-item-open disabled clearfix">
                     <span class="aria-label prevent-default" tabindex="0" role="button">{{_globals._accessibility._ariaLabels.locked}}. {{compile title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}</span>
@@ -74,5 +75,5 @@
         {{/if}}
     {{/each}}
     </div>
-    <div class="aria-label a11y-ignore-focus prevent-default" tabindex="0" aria-label="{{_globals._extensions._pageLevelProgress.pageLevelProgressEnd}}"/>
+    {{a11y_aria_label _globals._extensions._pageLevelProgress.pageLevelProgressEnd}}
 </div>

--- a/templates/pageLevelProgress.hbs
+++ b/templates/pageLevelProgress.hbs
@@ -7,10 +7,10 @@
         {{#if _isPartOfAssessment}}
             <div role="listitem" class="page-level-progress-item drawer-item">
                 {{#if _isVisible}}
-                <button class="base page-level-progress-item-title clearfix drawer-item-open" data-page-level-progress-id="{{_id}}" aria-label="{{compile title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}">
+                <button class="base page-level-progress-item-title clearfix drawer-item-open" data-page-level-progress-id="{{_id}}" aria-label="{{#if _isOptional}}{{_globals._extensions._pageLevelProgress.optionalContent}}{{else}}{{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}{{/if}} {{compile title}}">
                 {{else}}
                 <div class="page-level-progress-item-title drawer-item-open disabled clearfix">
-                    <span class="aria-label prevent-default" tabindex="0" role="button">{{_globals._accessibility._ariaLabels.locked}}. {{compile title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}</span>
+                    <span class="aria-label prevent-default" tabindex="0" role="button">{{#if _isOptional}}{{_globals._extensions._pageLevelProgress.optionalContent}}{{else}}{{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}{{/if}} {{_globals._accessibility._ariaLabels.locked}}. {{compile title}} </span>
                 {{/if}}
                     <div class="page-level-progress-item-title-inner accessible-text-block h5">
                     {{{compile title}}}
@@ -22,7 +22,7 @@
                         </div>
                     {{else}}
                         {{#if _isOptional}}
-                            <div class="page-level-progress-item-optional-text">
+                            <div class="page-level-progress-item-optional-text" aria-hidden="true">
                             {{_globals._extensions._pageLevelProgress.optionalContent}}
                             </div>
                         {{else}}
@@ -41,10 +41,10 @@
         {{else}}
             <div role="listitem" class="page-level-progress-item drawer-item">
                 {{#if _isVisible}}
-                <button class="base page-level-progress-item-title clearfix drawer-item-open" data-page-level-progress-id="{{_id}}" aria-label="{{compile title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}">
+                <button class="base page-level-progress-item-title clearfix drawer-item-open" data-page-level-progress-id="{{_id}}" aria-label="{{#if _isOptional}}{{_globals._extensions._pageLevelProgress.optionalContent}}{{else}}{{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}{{/if}} {{compile title}} ">
                 {{else}}
                 <div class="page-level-progress-item-title drawer-item-open disabled clearfix">
-                    <span class="aria-label prevent-default" tabindex="0" role="button">{{_globals._accessibility._ariaLabels.locked}}. {{compile title}} {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}</span>
+                    <span class="aria-label prevent-default" tabindex="0" role="button"> {{#if _isOptional}}{{_globals._extensions._pageLevelProgress.optionalContent}}{{else}}{{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}{{else}}{{_globals._accessibility._ariaLabels.incomplete}}{{/if}}{{/if}} {{_globals._accessibility._ariaLabels.locked}}. {{compile title}}</span>
                 {{/if}}
                     <div class="page-level-progress-item-title-inner accessible-text-block h5">
                     {{{compile title}}}
@@ -56,7 +56,7 @@
                         </div>
                     {{else}}
                         {{#if _isOptional}}
-                            <div class="page-level-progress-item-optional-text">
+                            <div class="page-level-progress-item-optional-text" aria-hidden="true">
                             {{_globals._extensions._pageLevelProgress.optionalContent}}
                             </div>
                         {{else}}

--- a/templates/pageLevelProgress.hbs
+++ b/templates/pageLevelProgress.hbs
@@ -75,5 +75,4 @@
         {{/if}}
     {{/each}}
     </div>
-    {{a11y_aria_label _globals._extensions._pageLevelProgress.pageLevelProgressEnd}}
 </div>

--- a/templates/pageLevelProgressMenu.hbs
+++ b/templates/pageLevelProgressMenu.hbs
@@ -1,3 +1,3 @@
 <div class="page-level-progress-menu-item-indicator">
-	<div class="page-level-progress-menu-item-indicator-bar" style="width:{{completedChildrenAsPercentage}}%"><span class="aria-label" role="region" tabindex="0"></span></div>
+	<div class="page-level-progress-menu-item-indicator-bar" style="width:{{completedChildrenAsPercentage}}%"><span class="aria-label"></span></div>
 </div>

--- a/templates/pageLevelProgressNavigation.hbs
+++ b/templates/pageLevelProgressNavigation.hbs
@@ -1,3 +1,5 @@
+{{! make the _globals object in course.json available to this template}}
+{{import_globals}}
 <div class="page-level-progress-navigation-completion">
     <div class="page-level-progress-navigation-bar"></div>
 </div>


### PR DESCRIPTION
[epic #1946](https://github.com/adaptlearning/adapt_framework/issues/1946)

[#2075](https://github.com/adaptlearning/adapt_framework/issues/2075)
* Removed unnecessary roles and tab indexes

[#2165](https://github.com/adaptlearning/adapt_framework/issues/2165)
* Updated aria labels to be more digestible 

General
* Switched to `a11y_aria_label`

