### PR TITLE
accessibility: issue/#2107 set focus on drawer close

### DIFF
--- a/js/PageLevelProgressView.js
+++ b/js/PageLevelProgressView.js
@@ -22,7 +22,7 @@ define([
 
             Adapt.once('drawer:closed', function() {
                 Adapt.scrollTo(currentComponentSelector, { duration: 400 });
-            }).trigger('drawer:closeDrawer');
+            }).trigger('drawer:closeDrawer', $(currentComponentSelector));
         },
 
         render: function() {


### PR DESCRIPTION
[epic #1946](https://github.com/adaptlearning/adapt_framework/issues/1946)

[#2107](https://github.com/adaptlearning/adapt_framework/issues/2107)
* Pass component container to drawerClose and popup manager so that when the drawer closes the popup manager knows where to assign the focus.