### PR TITLE
accessibility: issue/#2119 - .js-menu-item-progress selector for menu item progess

### DIFF
--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -38,7 +38,7 @@ define([
             var percentageComplete = Math.floor((completed / total) * 100);
 
             view.model.set('completedChildrenAsPercentage', percentageComplete);
-            view.$el.find('.menu-item-inner').append(new PageLevelProgressMenuView({model: view.model}).$el);
+            view.$el.find('.js-progress').append(new PageLevelProgressMenuView({model: view.model}).$el);
         }
     });
 

--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -38,7 +38,7 @@ define([
             var percentageComplete = Math.floor((completed / total) * 100);
 
             view.model.set('completedChildrenAsPercentage', percentageComplete);
-            view.$el.find('.js-progress').append(new PageLevelProgressMenuView({model: view.model}).$el);
+            view.$el.find('.js-menu-item-progress').append(new PageLevelProgressMenuView({model: view.model}).$el);
         }
     });
 


### PR DESCRIPTION
[epic #1946](https://github.com/adaptlearning/adapt_framework/issues/1946)

[#2119](https://github.com/adaptlearning/adapt_framework/issues/2119)
* changed selector for progress injection to `.js-menu-item-progress`

### Test with
[#83](https://github.com/adaptlearning/adapt-contrib-boxmenu/pull/83)