### PR TITLE
accessibility: issue/#2161 removed redundant code

### DIFF
--- a/js/PageLevelProgressView.js
+++ b/js/PageLevelProgressView.js
@@ -32,7 +32,6 @@ define([
             };
             var template = Handlebars.templates['pageLevelProgress'];
             this.$el.html(template(data));
-            this.$el.a11y_aria_label(true);
             return this;
         }
 


### PR DESCRIPTION
[#2161](https://github.com/adaptlearning/adapt_framework/issues/2161)
* Removed reference to deprecated `$.fn.a11y_aria_label`, deprecated in #2114