### PR TITLE
issue/2314: Utilize bubble:change:_isComplete for pageLevelProgress:percentageCompleteChange

### DIFF
--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -49,10 +49,14 @@ define([
 
         onCompletionChange: function(event) {
             var currentModel = Adapt.findById(Adapt.location._currentId);
-            Adapt.trigger("pageLevelProgress:percentageCompleteChange", {
-                current: completionCalculations.calculatePercentageComplete(currentModel),
+            var completionState = {
+                currentLocation: completionCalculations.calculatePercentageComplete(currentModel),
                 course: completionCalculations.calculatePercentageComplete(Adapt.course)
-            });
+            };
+            var hasChanged = !_.isMatch(this._previousCompletionState, completionState);
+            if (!hasChanged) return;
+            this._previousCompletionState = completionState;
+            Adapt.trigger("pageLevelProgress:percentageCompleteChange", completionState);
         },
 
         renderHeaderIndicatorView: function(view) {

--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -44,7 +44,7 @@ define([
                 'router:page': this.renderNavigationView
             });
 
-            this.listenTo(Adapt.course, "bubble:change:_isComplete", this.onCompletionChange);
+            this.listenTo(Adapt.course, 'bubble:change:_isComplete', this.onCompletionChange);
         },
 
         onCompletionChange: function(event) {
@@ -56,7 +56,7 @@ define([
             var hasChanged = !_.isMatch(this._previousCompletionState, completionState);
             if (!hasChanged) return;
             this._previousCompletionState = completionState;
-            Adapt.trigger("pageLevelProgress:percentageCompleteChange", completionState);
+            Adapt.trigger('pageLevelProgress:percentageCompleteChange', completionState);
         },
 
         renderHeaderIndicatorView: function(view) {

--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -43,6 +43,16 @@ define([
                 'menuView:postRender': this.renderMenuItemIndicatorView,
                 'router:page': this.renderNavigationView
             });
+
+            this.listenTo(Adapt.course, "bubble:change:_isComplete", this.onCompletionChange);
+        },
+
+        onCompletionChange: function(event) {
+            var currentModel = Adapt.findById(Adapt.location._currentId);
+            Adapt.trigger("pageLevelProgress:percentageCompleteChange", {
+                current: completionCalculations.calculatePercentageComplete(currentModel),
+                course: completionCalculations.calculatePercentageComplete(Adapt.course)
+            });
         },
 
         renderHeaderIndicatorView: function(view) {

--- a/js/completionCalculations.js
+++ b/js/completionCalculations.js
@@ -45,7 +45,7 @@ define([
                 completion.assessmentTotal = assessmentComponents.length;
                 completion.assessmentCompleted = getComponentsInteractionCompleted(assessmentComponents).length;
 
-                if (!contentObjectModel.get('_pageLevelProgress')._excludeAssessments) {
+                if (contentObjectModel.get('_pageLevelProgress')._excludeAssessments !== true) {
                     completion.subProgressCompleted = contentObjectModel.get('_subProgressComplete') || 0;
                     completion.subProgressTotal = contentObjectModel.get('_subProgressTotal') || 0;
                 }
@@ -61,13 +61,13 @@ define([
                 }
 
                 break;
-            case 'menu':
+            case 'menu': case 'course':
                 // If it's a sub-menu
                 children = contentObjectModel.get('_children').models;
                 children.forEach(function(contentObject) {
                     var completionObject = calculateCompletion(contentObject);
-                    completion.subProgressCompleted += contentObjectModel.subProgressCompleted || 0;
-                    completion.subProgressTotal += contentObjectModel.subProgressTotal || 0;
+                    completion.subProgressCompleted += completionObject.subProgressCompleted || 0;
+                    completion.subProgressTotal += completionObject.subProgressTotal || 0;
                     completion.nonAssessmentTotal += completionObject.nonAssessmentTotal;
                     completion.nonAssessmentCompleted += completionObject.nonAssessmentCompleted;
                     completion.assessmentTotal += completionObject.assessmentTotal;


### PR DESCRIPTION
[#2314](https://github.com/adaptlearning/adapt_framework/issues/2314)
* Utilised bubble:change:_isComplete for pageLevelProgress:percentageCompleteChange
* Fixed completionCalulation to allow course model
* Fixed bug in assessment calculation

```js
Adapt.on("pageLevelProgress:percentageCompleteChange", function(stateObject) {
   var currentLocationPercentComplete = stateObject.current;
   var coursePercentComplete = stateObject.course;
});
```

Please use with framework pr [#2315](https://github.com/adaptlearning/adapt_framework/pull/2315)
