### PR TITLE
Update help text for _showPageCompletion

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -125,7 +125,7 @@
                   "title": "Show page completion",
                   "inputType": "Checkbox",
                   "validators": [],
-                  "help": "Controls whether the progress calculations for this page are based on all components - or only those that are set to be displayed in Page Level Progress."
+                  "help": "Controls whether the progress calculations for this page are based on all components and the overall page - or only the components that are set to be displayed in Page Level Progress."
                 },
                 "_isCompletionIndicatorEnabled": {
                   "type": "boolean",


### PR DESCRIPTION
Page Level Progress has some text that could/should be updated possibly:

https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/blob/master/properties.schema#L80

Here it mentions that progress calculations are based on all components but this is actually all components + the page.

The functionality of whether the setting is true/false is all fine, its just the wording is slightly confusing.

True:

- component 1 (33%)
- component 2 (33%)
- page (33%)

False:

- component 1 (50%)
- component 2 (50%)
(the page can't be set to contribute to the PLP or not so doesn't get included in this calculation)