### PR TITLE
issue/2753 Switched from global remove to contentObject remove event (v5.5.0)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-pageLevelProgress",
   "version": "5.0.0",
-  "framework": ">=5.4",
+  "framework": ">=5.5",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-pageLevelProgress",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",
   "extension": "pageLevelProgress",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-pageLevelProgress",
   "version": "5.0.0",
-  "framework": ">=5",
+  "framework": ">=5.4",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-pageLevelProgress",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",
   "extension": "pageLevelProgress",

--- a/js/PageLevelProgressIndicatorView.js
+++ b/js/PageLevelProgressIndicatorView.js
@@ -6,6 +6,7 @@ define([
 
     initialize: function(options) {
       options = options || {};
+      this.parent = options.parent;
       this.calculatePercentage = options.calculatePercentage || this.calculatePercentage;
       this.ariaLabel = options.ariaLabel || '';
       this.type = options.type || this.model.get('_type');
@@ -33,7 +34,11 @@ define([
     },
 
     setUpEventListeners: function() {
-      this.listenTo(Adapt, 'remove', this.remove);
+      if (this.parent) {
+        this.listenToOnce(this.parent, 'postRemove', this.remove);
+      } else {
+        this.listenTo(Adapt, 'remove', this.remove);
+      }
       this.listenTo(this.model, 'change:_isComplete', this.refresh);
       if (!this.collection) return;
       this.listenTo(this.collection, 'change:_isComplete', this.refresh);

--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -87,6 +87,7 @@ define([
       $headings.each(function(index, el) {
         var $el = $(el);
         var indicatorView = new PageLevelProgressIndicatorView({
+          parent: view,
           model: model
         });
         indicatorView.$el.insertAfter($el);
@@ -113,6 +114,7 @@ define([
       }
 
       view.$el.find('.js-menu-item-progress').append(new PageLevelProgressIndicatorView({
+        parent: view,
         model: view.model,
         type: 'menu-item',
         calculatePercentage: this._getMenuItemCompletionPercentage.bind(view),


### PR DESCRIPTION
[#2753](https://github.com/adaptlearning/adapt_framework/issues/2753)
#### Changed
* Switched from global remove to contentObject remove event
* Updated framework dependency