### PR TITLE
issue/2762 Updated to use renderTo and disable _isLocked

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-pageLevelProgress",
   "version": "5.0.0",
-  "framework": ">=5.4",
+  "framework": ">=5.5",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-pageLevelProgress",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",
   "extension": "pageLevelProgress",

--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -27,7 +27,7 @@ define([
       this.listenTo(Adapt, {
         'remove': this.remove,
         'router:location': this.updateProgressBar,
-        'pageLevelProgress:update': this.refreshProgressBar
+        'view:childAdded pageLevelProgress:update': this.refreshProgressBar
       });
     },
 

--- a/js/PageLevelProgressView.js
+++ b/js/PageLevelProgressView.js
@@ -17,13 +17,24 @@ define([
       this.addChildren();
     },
 
-    scrollToPageElement: function(event) {
+    scrollToPageElement: async function(event) {
       if (event && event.preventDefault) event.preventDefault();
 
       var $target = $(event.currentTarget);
       if ($target.is('.is-disabled')) return;
 
-      var currentComponentSelector = '.' + $target.attr('data-pagelevelprogress-id');
+      var id = $target.attr('data-pagelevelprogress-id');
+      var model = Adapt.findById(id);
+
+      if (!model.get('_isRendered')) {
+        try {
+          await Adapt.parentView.renderTo(id);
+        } catch(err) {
+          return;
+        }
+      }
+
+      var currentComponentSelector = '.' + id;
 
       Adapt.once('drawer:closed', function() {
         Adapt.scrollTo(currentComponentSelector, { duration: 400 });

--- a/templates/pageLevelProgressItem.hbs
+++ b/templates/pageLevelProgressItem.hbs
@@ -1,7 +1,7 @@
 <button
-  class="pagelevelprogress__item-btn drawer__item-btn{{#unless _isVisible}} is-disabled{{/unless}} js-indicator js-pagelevelprogress-item-click"
+  class="pagelevelprogress__item-btn drawer__item-btn{{#any _isLocked (none _isVisible)}} is-disabled{{/any}} js-indicator js-pagelevelprogress-item-click"
   data-pagelevelprogress-id="{{_id}}"
-  aria-label="{{#unless _isVisible}}{{_globals._accessibility._ariaLabels.locked}}.{{/unless}}{{#if _isOptional}} {{_globals._extensions._pageLevelProgress.optionalContent}}.{{else}}{{#if _isComplete}} {{_globals._accessibility._ariaLabels.complete}}.{{else}} {{_globals._accessibility._ariaLabels.incomplete}}.{{/if}}{{/if}} {{compile title}}">
+  aria-label="{{#any _isLocked (none _isVisible)}}{{_globals._accessibility._ariaLabels.locked}}.{{/any}}{{#if _isOptional}} {{_globals._extensions._pageLevelProgress.optionalContent}}.{{else}}{{#if _isComplete}} {{_globals._accessibility._ariaLabels.complete}}.{{else}} {{_globals._accessibility._ariaLabels.incomplete}}.{{/if}}{{/if}} {{compile title}}">
 
   <div class="pagelevelprogress__item-title drawer__item-title">
     <div class="pagelevelprogress__item-title-inner drawer__item-title-inner">


### PR DESCRIPTION
[#2762](https://github.com/adaptlearning/adapt_framework/issues/2762)

#### Changes
* `Adapt.parentView.renderTo` to ensure content is rendered before scrolling to
* Listen to `view:childAdded` to update status bars and lists when new views are added
* Disable `_isLocked` models

