### PR TITLE
issue/134 Added import_globals to item handlebars

### DIFF
--- a/templates/pageLevelProgressItem.hbs
+++ b/templates/pageLevelProgressItem.hbs
@@ -1,3 +1,4 @@
+{{import_globals}}
 <button
   class="pagelevelprogress__item-btn drawer__item-btn{{#any _isLocked (none _isVisible)}} is-disabled{{/any}} js-indicator js-pagelevelprogress-item-click"
   data-pagelevelprogress-id="{{_id}}"


### PR DESCRIPTION
fixes #134 

### Fixed
* Added `{{import_globals}}` to ensure they are always available in the template regardless of whether the source model has `_globals` in it already