### PR TITLE
issue/2799 Remove redundant behaviour

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-pageLevelProgress",
   "version": "5.4.0",
-  "framework": ">=5.18.6",
+  "framework": ">=5.19.1",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-pageLevelProgress",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/issues",
   "extension": "pageLevelProgress",

--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -16,7 +16,7 @@ export default class PageLevelProgressNavigationView extends Backbone.View {
   attributes() {
     return {
       'data-order': (Adapt.course.get('_globals')?._extensions?._pageLevelProgress?._navOrder || 0)
-    }
+    };
   }
 
   events() {

--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -1,4 +1,5 @@
 import Adapt from 'core/js/adapt';
+import drawer from 'core/js/drawer';
 import completionCalculations from './completionCalculations';
 import PageLevelProgressView from './PageLevelProgressView';
 import PageLevelProgressIndicatorView from './PageLevelProgressIndicatorView';
@@ -75,7 +76,7 @@ export default class PageLevelProgressNavigationView extends Backbone.View {
 
   onProgressClicked(event) {
     if (event && event.preventDefault) event.preventDefault();
-    Adapt.drawer.triggerCustomView(new PageLevelProgressView({
+    drawer.triggerCustomView(new PageLevelProgressView({
       collection: this.collection
     }).$el, false);
   }

--- a/js/PageLevelProgressView.js
+++ b/js/PageLevelProgressView.js
@@ -1,4 +1,6 @@
 import Adapt from 'core/js/adapt';
+import data from 'core/js/data';
+import router from 'core/js/router';
 import PageLevelProgressItemView from './PageLevelProgressItemView';
 
 export default class PageLevelProgressView extends Backbone.View {
@@ -26,7 +28,7 @@ export default class PageLevelProgressView extends Backbone.View {
     if ($target.is('.is-disabled')) return;
 
     const id = $target.attr('data-pagelevelprogress-id');
-    const model = Adapt.findById(id);
+    const model = data.findById(id);
 
     if (!model.get('_isRendered')) {
       try {
@@ -39,7 +41,7 @@ export default class PageLevelProgressView extends Backbone.View {
     const currentComponentSelector = `.${id}`;
 
     Adapt.once('drawer:closed', () => {
-      Adapt.scrollTo(currentComponentSelector, { duration: 400 });
+      router.navigateToElement(currentComponentSelector, { duration: 400 });
     }).trigger('drawer:closeDrawer', $(currentComponentSelector));
   }
 

--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -73,7 +73,7 @@ class PageLevelProgress extends Backbone.Controller {
     const config = model.get('_pageLevelProgress');
     if (!config?._isEnabled || !config?._isCompletionIndicatorEnabled) return;
 
-    const pageModel = model.findAncestor('contentObjects');
+    const pageModel = model.findAncestor('contentobject');
     const pageConfig = pageModel && pageModel.get('_pageLevelProgress');
     if (!pageConfig?._isEnabled) return;
 

--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -1,4 +1,6 @@
 import Adapt from 'core/js/adapt';
+import data from 'core/js/data';
+import location from 'core/js/location';
 import completionCalculations from './completionCalculations';
 import PageLevelProgressNavigationView from './PageLevelProgressNavigationView';
 import PageLevelProgressIndicatorView from './PageLevelProgressIndicatorView';
@@ -54,9 +56,9 @@ class PageLevelProgress extends Backbone.Controller {
   }
 
   onCompletionChange(event) {
-    if (!Adapt.location._currentId) return;
+    if (!location._currentId) return;
 
-    const currentModel = Adapt.findById(Adapt.location._currentId);
+    const currentModel = data.findById(location._currentId);
     const completionState = {
       currentLocation: completionCalculations.calculatePercentageComplete(currentModel),
       course: completionCalculations.calculatePercentageComplete(Adapt.course)
@@ -91,7 +93,7 @@ class PageLevelProgress extends Backbone.Controller {
   // This should add/update progress on menuView
   renderMenuItemIndicatorView(view) {
     // Do not render on menu, only render on menu items
-    if (view.model.get('_id') === Adapt.location._currentId) return;
+    if (view.model.get('_id') === location._currentId) return;
 
     // Progress bar should not render for course viewType
     const viewType = view.model.get('_type');

--- a/js/completionCalculations.js
+++ b/js/completionCalculations.js
@@ -21,7 +21,7 @@ class Completion extends Backbone.Controller {
     let children;
 
     switch (viewType) {
-      case 'page':
+      case 'page': {
         // If it's a page
         children = contentObjectModel.getAllDescendantModels().filter(model => {
           return model.get('_isAvailable') && !model.get('_isOptional');
@@ -55,9 +55,10 @@ class Completion extends Backbone.Controller {
         }
 
         break;
-      case 'menu': case 'course':
+      }
+      case 'menu': case 'course': {
         // If it's a sub-menu
-        children = contentObjectModel.get('_children').models;
+        children = contentObjectModel.getChildren().models;
         children.forEach(contentObject => {
           const completionObject = Adapt.completion.calculateCompletion(contentObject);
           completion.subProgressCompleted += completionObject.subProgressCompleted || 0;
@@ -68,6 +69,7 @@ class Completion extends Backbone.Controller {
           completion.assessmentCompleted += completionObject.assessmentCompleted;
         });
         break;
+      }
 
     }
 


### PR DESCRIPTION
requires https://github.com/adaptlearning/adapt-contrib-core/pull/84
part of https://github.com/adaptlearning/adapt_framework/issues/2799

### Changed
* Use `drawer`, `router`, `data` and `location` directly
* Switch from `model.get('_children')` to `model.getChildren()`