### PR TITLE
Reinstate third curly brace on aria label

### DIFF
--- a/templates/pageLevelProgressItem.hbs
+++ b/templates/pageLevelProgressItem.hbs
@@ -2,7 +2,7 @@
 <button
   class="pagelevelprogress__item-btn drawer__item-btn{{#any _isLocked (none _isVisible)}} is-disabled{{/any}} js-indicator js-pagelevelprogress-item-click"
   data-pagelevelprogress-id="{{_id}}"
-  aria-label="{{#any _isLocked (none _isVisible)}}{{_globals._accessibility._ariaLabels.locked}}.{{/any}}{{#if _isOptional}} {{_globals._extensions._pageLevelProgress.optionalContent}}.{{else}}{{#if _isComplete}} {{_globals._accessibility._ariaLabels.complete}}.{{else}} {{_globals._accessibility._ariaLabels.incomplete}}.{{/if}}{{/if}} {{compile_a11y_normalize title}}">
+  aria-label="{{#any _isLocked (none _isVisible)}}{{_globals._accessibility._ariaLabels.locked}}.{{/any}}{{#if _isOptional}} {{_globals._extensions._pageLevelProgress.optionalContent}}.{{else}}{{#if _isComplete}} {{_globals._accessibility._ariaLabels.complete}}.{{else}} {{_globals._accessibility._ariaLabels.incomplete}}.{{/if}}{{/if}} {{{compile_a11y_normalize title}}}">
 
   <div class="pagelevelprogress__item-title drawer__item-title">
     <div class="pagelevelprogress__item-title-inner drawer__item-title-inner">


### PR DESCRIPTION
Resolves https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/issues/141

* Reinstate third curly brace on aria label within pageLevelProgressItem.hbs