### PR TITLE
Fix: Remove nav PLP btn line height (fixes #155)

### DIFF
--- a/less/pageLevelProgress.less
+++ b/less/pageLevelProgress.less
@@ -3,7 +3,6 @@
 .nav {
   &__pagelevelprogress-btn {
     .u-float-right;
-    line-height: 0;
     padding: @icon-size (@icon-size / 2);
   }
 }

--- a/less/pageLevelProgressIndicator.less
+++ b/less/pageLevelProgressIndicator.less
@@ -2,8 +2,7 @@
 // --------------------------------------------------
 .pagelevelprogress {
   &__indicator {
-    display: inline-block;
-    vertical-align: middle;
+    display: flex;
     width: 2rem;
     font-size: 1rem;
     border: 0.0625rem solid @black;
@@ -15,6 +14,7 @@
     position: relative;
     display: block;
     height: @icon-size / 4;
+    width: 100%;
   }
 
   &__indicator-bar {


### PR DESCRIPTION
Fixes: #155 

### Fix
* Removed line height style from `nav__pagelevelprogress-btn` selector
* Added alternative styles to indicator elements to resolve issue
