### PR TITLE
Fix: Drawer not closing when switching between content objects (#160)

### DIFF
--- a/js/PageLevelProgressView.js
+++ b/js/PageLevelProgressView.js
@@ -34,6 +34,7 @@ export default class PageLevelProgressView extends Backbone.View {
 
     if (isNavigateToContentObject) {
       router.navigateToElement(id, { duration: 400 });
+      Adapt.trigger('drawer:closeDrawer');
       return;
     }
 


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
fixes(https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/issues/160)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Drawer not closing automatically when switching between content objects

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Set PLP _showAtCourseLevel to true
2. Open PLP and select a different content object
3. Check that drawer closes automatically

[//]: # (Mention any other dependencies)


