### PR TITLE
New: Context specific indicator click, allow course indicator

### DIFF
--- a/js/PageLevelProgressIndicatorView.js
+++ b/js/PageLevelProgressIndicatorView.js
@@ -1,4 +1,7 @@
 import Adapt from 'core/js/adapt';
+import drawer from 'core/js/drawer';
+import PageLevelProgressView from './PageLevelProgressView';
+import getPageLevelProgressItemsJSON from './getPageLevelProgressItems';
 
 class PageLevelProgressIndicatorView extends Backbone.View {
 
@@ -17,6 +20,23 @@ class PageLevelProgressIndicatorView extends Backbone.View {
     this.setPercentageComplete();
     this.render();
     this.refresh();
+  }
+
+  events() {
+    return {
+      'click *': this.onClick
+    };
+  }
+
+  onClick(event) {
+    if (event && event.preventDefault) event.preventDefault();
+    const parentModel = this.parent.model;
+    const model = !parentModel.isTypeGroup('contentobject')
+      ? parentModel.findAncestor('contentobject')
+      : parentModel;
+    drawer.triggerCustomView(new PageLevelProgressView({
+      collection: getPageLevelProgressItemsJSON(model)
+    }).$el, false);
   }
 
   addClasses() {

--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -77,7 +77,7 @@ class PageLevelProgress extends Backbone.Controller {
 
     const pageModel = model.findAncestor('contentobject');
     const pageConfig = pageModel && pageModel.get('_pageLevelProgress');
-    if (!pageConfig?._isEnabled) return;
+    if (pageModel && !pageConfig?._isEnabled) return;
 
     const $headings = view.$('.js-heading');
     $headings.each((index, el) => {


### PR DESCRIPTION
fixes #167 

### New
* Course completion indicator
* Clickability to indicators, showing the plp from the context of the clicked indicator

### Todo
* Main menu progress bar should be granular (a notch for each bit) rather than binary (complete/incomplete)
* General progress bar could/should be added under the navigation bar

### Testing
* Use `course.json:_pageLevelProgress._showAtCourseLevel = true`
* Click on a page-level (menu item) progress bar to see the plp change context
