### PR TITLE
Update: aria-label updates (fixes #170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The same **\_pageLevelProgress** object may be added to the course (_course.json
 
 ### Accessibility
 
-Several elements of **Page Level Progress** have been assigned a label using the [aria-label](https://github.com/adaptlearning/adapt_framework/wiki/Aria-Labels) attribute: **pageLevelProgress**, **pageLevelProgressIndicatorBar**, and **pageLevelProgressEnd**. These labels are not visible elements. They are utilized by assistive technology such as screen readers. Should the label texts need to be customised, they can be found within the **globals** object in [_properties.schema_](https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/blob/master/properties.schema).
+Several elements of **Page Level Progress** have been assigned a label using the [aria-label](https://github.com/adaptlearning/adapt_framework/wiki/Aria-Labels) attribute: **pageLevelProgress**, **pageLevelProgressIndicatorBar** and **pageLevelProgressMenuBar**. These labels are not visible elements. They are utilized by assistive technology such as screen readers. Should the label texts need to be customised, they can be found within the **globals** object in [_properties.schema_](https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/blob/master/properties.schema).
 
 <div float align=right><a href="#top">Back to Top</a></div>
 

--- a/properties.schema
+++ b/properties.schema
@@ -7,7 +7,7 @@
     "pageLevelProgress": {
       "type": "string",
       "required": true,
-      "default": "Page sections",
+      "default": "List of page sections and completion status. Select incomplete sections to jump directly to the content.",
       "inputType": "Text",
       "validators": [],
       "translatable": true
@@ -15,7 +15,7 @@
     "pageLevelProgressIndicatorBar": {
       "type": "string",
       "required": true,
-      "default": "Page progress. Use this to listen to the list of regions in this topic and whether they're completed. You can jump directly to any that are incomplete or which sound particularly interesting. {{percentageComplete}}%",
+      "default": "Page progress. {{percentageComplete}}%. Open page sections.",
       "inputType": "Text",
       "validators": [],
       "translatable": true
@@ -24,14 +24,6 @@
       "type": "string",
       "required": true,
       "default": "Page completion {{percentageComplete}}%",
-      "inputType": "Text",
-      "validators": [],
-      "translatable": true
-    },
-    "pageLevelProgressEnd": {
-      "type": "string",
-      "required": true,
-      "default": "You have reached the end of the list of page sections.",
       "inputType": "Text",
       "validators": [],
       "translatable": true

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -24,7 +24,7 @@
                     "pageLevelProgress": {
                       "type": "string",
                       "title": "Page Level Progress",
-                      "default": "Page sections",
+                      "default": "List of page sections and completion status. Select incomplete sections to jump directly to the content.",
                       "_adapt": {
                         "translatable": true
                       }
@@ -32,7 +32,7 @@
                     "pageLevelProgressIndicatorBar": {
                       "type": "string",
                       "title": "Page Level Progress indicator bar",
-                      "default": "Page progress. Use this to listen to the list of regions in this topic and whether they're completed. You can jump directly to any that are incomplete or which sound particularly interesting. {{percentageComplete}}%",
+                      "default": "Page progress. {{percentageComplete}}%. Open page sections.",
                       "_adapt": {
                         "translatable": true
                       }
@@ -41,14 +41,6 @@
                       "type": "string",
                       "title": "Page Level Progress menu bar",
                       "default": "Page completion {{percentageComplete}}%",
-                      "_adapt": {
-                        "translatable": true
-                      }
-                    },
-                    "pageLevelProgressEnd": {
-                      "type": "string",
-                      "title": "Page Level Progress end",
-                      "default": "You have reached the end of the list of page sections.",
                       "_adapt": {
                         "translatable": true
                       }


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/issues/170
- shorten `pageLevelProgressIndicatorBar` `aria-label` (nav button label)
- add instruction to `pageLevelProgress` `aria-label` (drawer label)

**Current nav bar button aria-label:**
_"Page progress. Use this to listen to the list of regions in this topic and whether they're completed. You can jump directly to any that are incomplete or which sound particularly interesting. {{percentageComplete}}%"_

**Current PLP drawer aria-label (this is read when the PLP drawer is opened before you interact with the PLP items):**
_"Page sections"_

**Updated nav bar button aria-label:**
_"Page progress. {{percentageComplete}}%. Open page sections."_

**Updated PLP drawer aria-label (this is read when the PLP drawer is opened before you interact with the PLP items):**
_"List of page sections and completion status. Select incomplete sections to jump directly to the content."_



Fixes https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/issues/169
- remove `pageLevelProgressEnd` `aria-label` as this isn't used.






