### PR TITLE
Breaking: Navigation Button API compatibility (fixes #173)

### DIFF
--- a/example.json
+++ b/example.json
@@ -3,7 +3,8 @@
       "_extensions": {
         "_pageLevelProgress": {
           "_navOrder": 90,
-          "_comment": "Position options include 'auto', 'left', and 'right'"
+          "navLabel": "Page progress",
+          "_comment": "Position options include 'auto', 'left', and 'right'",
           "_drawerPosition": "auto"
         }
       }

--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -57,7 +57,8 @@ export default class PageLevelProgressNavigationView extends Backbone.View {
       calculatePercentage: this._getPageCompletionPercentage,
       ariaLabel: Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressIndicatorBar
     });
-    this.$el.prepend(this.indicatorView.$el);
+    const $wrapper = this.$el.find('.pagelevelprogress__indicator-wrapper');
+    $wrapper.prepend(this.indicatorView.$el);
   }
 
   _getPageCompletionPercentage() {

--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -5,22 +5,9 @@ import completionCalculations from './completionCalculations';
 import PageLevelProgressView from './PageLevelProgressView';
 import PageLevelProgressIndicatorView from './PageLevelProgressIndicatorView';
 import getPageLevelProgressItemsJSON from './getPageLevelProgressItems';
+import NavigationButtonView from 'core/js/views/NavigationButtonView';
 
-export default class PageLevelProgressNavigationView extends Backbone.View {
-
-  tagName() {
-    return 'button';
-  }
-
-  className() {
-    return 'btn-icon nav__btn nav__pagelevelprogress-btn pagelevelprogress__nav-btn';
-  }
-
-  attributes() {
-    return {
-      'data-order': this.globalsConfig?._navOrder ?? 0
-    };
-  }
+export default class PageLevelProgressNavigationView extends NavigationButtonView {
 
   events() {
     return {
@@ -28,7 +15,22 @@ export default class PageLevelProgressNavigationView extends Backbone.View {
     };
   }
 
-  initialize() {
+  attributes() {
+    const attributes = this.model.toJSON();
+    return {
+      name: attributes._id,
+      role: attributes._role === 'button' ? undefined : attributes._role,
+      'data-order': attributes._order
+    };
+  }
+
+  static get template() {
+    return 'pageLevelProgressNavigationButton.jsx';
+  }
+
+  initialize(options) {
+    super.initialize(options);
+    this.pageModel = options.pageModel;
     _.bindAll(this, 'updateProgressBar');
     this.refreshProgressBar = _.debounce(this.refreshProgressBar.bind(this), 16);
     this.setUpEventListeners();
@@ -46,23 +48,18 @@ export default class PageLevelProgressNavigationView extends Backbone.View {
     this.listenTo(data, 'change:_isLocked change:_isComplete', this.refreshProgressBar);
   }
 
-  render() {
-    const template = Handlebars.templates.pageLevelProgressNavigation;
-    this.$el.html(template({}));
-  }
-
   addIndicator() {
     this.indicatorView = new PageLevelProgressIndicatorView({
-      model: this.model,
-      calculatePercentage: this._getPageCompletionPercentage,
-      ariaLabel: this.globalsConfig?.pageLevelProgressIndicatorBar
+      model: this.pageModel,
+      calculatePercentage: this._getPageCompletionPercentage.bind(this),
+      ariaLabel: this.model.get('ariaLabel')
     });
     const $wrapper = this.$el.find('.pagelevelprogress__indicator-wrapper');
     $wrapper.prepend(this.indicatorView.$el);
   }
 
   _getPageCompletionPercentage() {
-    return completionCalculations.calculatePercentageComplete(this.model, true);
+    return completionCalculations.calculatePercentageComplete(this.pageModel, true);
   }
 
   deferredUpdate() {
@@ -74,19 +71,15 @@ export default class PageLevelProgressNavigationView extends Backbone.View {
   }
 
   refreshProgressBar() {
-    this.collection = getPageLevelProgressItemsJSON(this.model);
+    this.collection = getPageLevelProgressItemsJSON(this.pageModel);
     this.updateProgressBar();
-  }
-
-  get globalsConfig() {
-    return Adapt.course.get('_globals')?._extensions?._pageLevelProgress;
   }
 
   onProgressClicked(event) {
     if (event && event.preventDefault) event.preventDefault();
     drawer.triggerCustomView(new PageLevelProgressView({
       collection: this.collection
-    }).$el, false, this.globalsConfig?._drawerPosition);
+    }).$el, false, this.model.get('_drawerPosition'));
   }
 
   remove() {

--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -144,16 +144,23 @@ class PageLevelProgress extends Backbone.Controller {
     const collection = getPageLevelProgressItems(pageModel);
     if (!collection) return;
 
+    const {
+      _navOrder = 0,
+      _showLabel = true,
+      navLabel = '',
+      _drawerPosition = 'auto'
+    } = PageLevelProgress.globalsConfig ?? {};
+
     const model = new NavigationButtonModel({
       _id: 'pagelevelprogress',
-      _order: PageLevelProgress.globalsConfig?._navOrder ?? 0,
-      _showLabel: PageLevelProgress.globalsConfig?._showLabel ?? true,
+      _order: _navOrder,
+      _showLabel,
       _classes: 'nav__pagelevelprogress-btn pagelevelprogress__nav-btn',
       _iconClasses: '',
       _role: 'button',
-      ariaLabel: PageLevelProgress.globalsConfig?.pageLevelProgressIndicatorBar,
-      text: PageLevelProgress.globalsConfig?.navLabel ?? '',
-      _drawerPosition: PageLevelProgress.globalsConfig?._drawerPosition ?? 'auto'
+      ariaLabel: pageLevelProgressIndicatorBar,
+      text: navLabel,
+      _drawerPosition
     });
 
     navigation.addButton(new PageLevelProgressNavigationView({

--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -5,6 +5,8 @@ import completionCalculations from './completionCalculations';
 import PageLevelProgressNavigationView from './PageLevelProgressNavigationView';
 import PageLevelProgressIndicatorView from './PageLevelProgressIndicatorView';
 import getPageLevelProgressItems from './getPageLevelProgressItems';
+import navigation from 'core/js/navigation';
+import NavigationButtonModel from 'core/js/models/NavigationButtonModel';
 
 class PageLevelProgress extends Backbone.Controller {
 
@@ -15,13 +17,17 @@ class PageLevelProgress extends Backbone.Controller {
     });
   }
 
-  getCourseConfig() {
+  static get globalsConfig() {
+    return Adapt.course.get('_globals')?._extensions?._pageLevelProgress;
+  }
+
+  static get courseConfig() {
     return Adapt.course.get('_pageLevelProgress');
   }
 
   onDataReady() {
     // Do not proceed if pageLevelProgress is not enabled in course.json
-    const coursePLPConfig = this.getCourseConfig();
+    const coursePLPConfig = PageLevelProgress.courseConfig;
     if (!coursePLPConfig?._isEnabled) return;
     this.setUpEventListeners();
   }
@@ -113,7 +119,7 @@ class PageLevelProgress extends Backbone.Controller {
       model: view.model,
       type: 'menu-item',
       calculatePercentage: this._getMenuItemCompletionPercentage.bind(view),
-      ariaLabel: Adapt.course.get('_globals')._extensions._pageLevelProgress.pageLevelProgressMenuBar
+      ariaLabel: PageLevelProgress.globalsConfig?.pageLevelProgressMenuBar
     }).$el);
   }
 
@@ -124,7 +130,7 @@ class PageLevelProgress extends Backbone.Controller {
   // This should add/update progress on page navigation bar
   renderNavigationView(pageModel) {
     // Do not render if turned off at course level
-    const coursePLPConfig = this.getCourseConfig();
+    const coursePLPConfig = PageLevelProgress.courseConfig;
     if (coursePLPConfig?._isShownInNavigationBar === false) return;
 
     // Do not proceed if pageLevelProgress is not enabled for the content object
@@ -138,10 +144,23 @@ class PageLevelProgress extends Backbone.Controller {
     const collection = getPageLevelProgressItems(pageModel);
     if (!collection) return;
 
-    $('.nav__drawer-btn').after(new PageLevelProgressNavigationView({
-      model: pageModel,
+    const model = new NavigationButtonModel({
+      _id: 'pagelevelprogress',
+      _order: PageLevelProgress.globalsConfig?._navOrder ?? 0,
+      _showLabel: PageLevelProgress.globalsConfig?._showLabel ?? true,
+      _classes: 'nav__pagelevelprogress-btn pagelevelprogress__nav-btn',
+      _iconClasses: '',
+      _role: 'button',
+      ariaLabel: PageLevelProgress.globalsConfig?.pageLevelProgressIndicatorBar,
+      text: PageLevelProgress.globalsConfig?.navLabel ?? '',
+      _drawerPosition: PageLevelProgress.globalsConfig?._drawerPosition ?? 'auto'
+    });
+
+    navigation.addButton(new PageLevelProgressNavigationView({
+      model,
+      pageModel,
       collection
-    }).$el);
+    }));
   }
 
 }

--- a/js/adapt-contrib-pageLevelProgress.js
+++ b/js/adapt-contrib-pageLevelProgress.js
@@ -148,6 +148,7 @@ class PageLevelProgress extends Backbone.Controller {
       _navOrder = 0,
       _showLabel = true,
       navLabel = '',
+      pageLevelProgressIndicatorBar = '',
       _drawerPosition = 'auto'
     } = PageLevelProgress.globalsConfig ?? {};
 

--- a/less/pageLevelProgress.less
+++ b/less/pageLevelProgress.less
@@ -1,8 +1,10 @@
 // PLP nav bar button
 // --------------------------------------------------
-.nav {
-  &__pagelevelprogress-btn {
-    padding: @icon-size (@icon-size / 2);
+.pagelevelprogress {
+  &__nav-btn &__indicator-wrapper {
+    display: inline-flex;
+    align-items: center;
+    min-height: @icon-size;
   }
 }
 

--- a/properties.schema
+++ b/properties.schema
@@ -43,6 +43,24 @@
       "inputType": "Text",
       "validators": []
     },
+    "_showLabel": {
+      "type": "boolean",
+      "required": true,
+      "default": true,
+      "title": "Enable navigation bar button label",
+      "inputType": "Checkbox",
+      "validators": [],
+      "help": "Controls whether a label is shown on the navigation bar button."
+    },
+    "navLabel": {
+      "type": "string",
+      "required": true,
+      "default": "Page progress",
+      "title": "Navigation bar button label",
+      "inputType": "Text",
+      "validators": [],
+      "translatable": true
+    },
     "_drawerPosition": {
       "type": "string",
       "required": true,

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -58,6 +58,19 @@
                       "title": "Navigation bar order",
                       "default": 90
                     },
+                    "_showLabel": {
+                      "type": "boolean",
+                      "title": "Enable navigation bar button label",
+                      "default": true
+                    },
+                    "navLabel": {
+                      "type": "string",
+                      "title": "Navigation bar button label",
+                      "default": "Page Progress",
+                      "_adapt": {
+                        "translatable": true
+                      }
+                    },
                     "_drawerPosition": {
                       "type": "string",
                       "default": "auto",

--- a/templates/pageLevelProgressNavigation.hbs
+++ b/templates/pageLevelProgressNavigation.hbs
@@ -1,4 +1,0 @@
-{{! make the _globals object in course.json available to this template}}
-{{import_globals}}
-
-<div class="pagelevelprogress__indicator-wrapper"></div>

--- a/templates/pageLevelProgressNavigation.hbs
+++ b/templates/pageLevelProgressNavigation.hbs
@@ -2,7 +2,3 @@
 {{import_globals}}
 
 <div class="pagelevelprogress__indicator-wrapper"></div>
-
-<span class="tooltip">
-  {{_globals._accessibility._ariaLabels.progress}}
-</span>

--- a/templates/pageLevelProgressNavigation.hbs
+++ b/templates/pageLevelProgressNavigation.hbs
@@ -1,6 +1,8 @@
 {{! make the _globals object in course.json available to this template}}
 {{import_globals}}
 
+<div class="pagelevelprogress__indicator-wrapper"></div>
+
 <span class="tooltip">
   {{_globals._accessibility._ariaLabels.progress}}
 </span>

--- a/templates/pageLevelProgressNavigationButton.jsx
+++ b/templates/pageLevelProgressNavigationButton.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { classes, compile } from 'core/js/reactHelpers';
+
+export default function PageLevelProgressNavigationButton(props) {
+  const {
+    text,
+    _iconClasses
+  } = props;
+  return (
+    <React.Fragment>
+      <span
+        className={classes([
+          'icon',
+          _iconClasses
+        ])}
+        aria-hidden="true"
+      />
+      <div className="pagelevelprogress__indicator-wrapper" />
+      <span className="nav__btn-label" aria-hidden="true">{compile(text, props)}</span>
+    </React.Fragment>
+  );
+}


### PR DESCRIPTION
Fix #173 

### Fix
* Normalizes the nav button padding
* Adds an indicator container and sets it to the same height as the other nav button icons. This should ideally keep the indicator and text aligned with other nav buttons.

### Breaking
* Uses new Navigation Button API for the nav button

### Testing
1. `adapt-contrib-core`: Switch to the `issue/338` branch
2. In `course.json`, enable nav text labels:

```
  "_navigation": {
    "_showLabel": true
  },
```

[//]: # (Mention any other dependencies)
Dependent on https://github.com/adaptlearning/adapt-contrib-core/pull/339 for the new text label functionality.

