### PR TITLE
Fix: Add CSS classes when using _showAtCourseLevel (fixes #176)

### DIFF
--- a/js/PageLevelProgressView.js
+++ b/js/PageLevelProgressView.js
@@ -8,7 +8,11 @@ import { templates } from 'core/js/reactHelpers';
 export default class PageLevelProgressView extends Backbone.View {
 
   className() {
-    return 'pagelevelprogress';
+    const config = Adapt.course.get('_pageLevelProgress');
+    return [
+      'pagelevelprogress',
+      (config._showAtCourseLevel === true) && 'is-course-level'
+    ].filter(Boolean).join(' ');
   }
 
   events() {

--- a/templates/pageLevelProgressItem.jsx
+++ b/templates/pageLevelProgressItem.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { compile, classes } from 'core/js/reactHelpers';
 import a11y from 'core/js/a11y';
 import data from 'core/js/data';
+import location from 'core/js/location';
 import completionCalculations from '../js/completionCalculations';
 import PageLevelProgressIndicatorView from '../js/PageLevelProgressIndicatorView';
 
@@ -29,11 +30,18 @@ export default function PageLevelProgressItem(props) {
     $(indicatorSeat.current).append(item.$el);
   });
 
+  const isCurrentPage = (id, type) => {
+    if ((type !== 'page') || location._currentModel.get('_id') !== id) { return false; }
+
+    return true;
+  };
+
   return (
     <div
       className={classes([
         'pagelevelprogress__item drawer__item',
-        `${_type}__indicator`
+        `${_type}__indicator`,
+        isCurrentPage(_id, _type) && 'is-current-page'
       ])}
       role='listitem'
     >


### PR DESCRIPTION
Fixes #176 

### Fix
When `_showAtCourseLevel` is set to 'true':
* Adds the class `is-course-level` to `.pagelevelprogress`
* Adds the class `is-current-page` to the current page's `.pagelevelprogress__item`

No styles were added or changed.

### Testing
1. In _course.json_, set `_showAtCourseLevel` to true
2. Add some styles to your theme:

```
.pagelevelprogress__item.is-current-page > .pagelevelprogress__item-btn {
  background-color: yellow;
  color: black;
}
```

3. Visit a page and check that the current page is highlighted in the PLP drawer.

[//]: # (Mention any other dependencies)


