### PR TITLE
Fix: Missing navigation bar ordering description (fixes #162)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -39,6 +39,8 @@
     "_navOrder": {
       "type": "number",
       "required": true,
+      "title": "Navigation bar order",
+      "help": "Determines the order in which the page level progress is displayed in the navigation bar. Negative numbers (e.g. -100) are left-aligned. Positive numbers (e.g. 100) are right-aligned.",
       "default": 90,
       "inputType": "Text",
       "validators": []
@@ -47,7 +49,8 @@
       "type": "string",
       "required": true,
       "default": "auto",
-      "title":"Drawer position",
+      "title": "Drawer position",
+      "help": "Determines the starting position of the drawer to open.",
       "inputType": {
         "type": "Select",
         "options": [
@@ -56,8 +59,7 @@
           "right"
         ]
       },
-      "validators": [],
-      "help": "Determines the starting position of the drawer to open."
+      "validators": []
     }
   },
   "properties": {

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -56,18 +56,19 @@
                     "_navOrder": {
                       "type": "number",
                       "title": "Navigation bar order",
+                      "description": "Determines the order in which the page level progress is displayed in the navigation bar. Negative numbers (e.g. -100) are left-aligned. Positive numbers (e.g. 100) are right-aligned.",
                       "default": 90
                     },
                     "_drawerPosition": {
                       "type": "string",
                       "default": "auto",
-                      "title":"Drawer position",
+                      "title": "Drawer position",
+                      "description": "Determines the starting position of the drawer to open",
                       "enum": [
                         "auto",
                         "left",
                         "right"
-                      ],
-                      "help": "Determines the starting position of the drawer to open"
+                      ]
                     }
                   }
                 }


### PR DESCRIPTION
Fixes #162 

### Fix
* Adds a description (tooltip) for the `_navOrder` property
* Adds a title for `_navOrder` in _properties.schema_
* Minor adjustments to `_drawerPosition` - Use 'description' instead of 'help' in _course.schema.json_, missing space, and move closer to 'title'