### PR TITLE
New: Add support for tooltip API (fixes #186)

### DIFF
--- a/example.json
+++ b/example.json
@@ -5,7 +5,11 @@
           "_navOrder": 90,
           "navLabel": "Page progress",
           "_comment": "Position options include 'auto', 'left', and 'right'",
-          "_drawerPosition": "auto"
+          "_drawerPosition": "auto",
+          "_navTooltip": {
+            "_isEnabled": true,
+            "text": "Page progress"
+          }
         }
       }
     }

--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -6,6 +6,7 @@ import PageLevelProgressView from './PageLevelProgressView';
 import PageLevelProgressIndicatorView from './PageLevelProgressIndicatorView';
 import getPageLevelProgressItemsJSON from './getPageLevelProgressItems';
 import NavigationButtonView from 'core/js/views/NavigationButtonView';
+import tooltips from 'core/js/tooltips';
 
 export default class PageLevelProgressNavigationView extends NavigationButtonView {
 
@@ -20,7 +21,8 @@ export default class PageLevelProgressNavigationView extends NavigationButtonVie
     return {
       name: attributes._id,
       role: attributes._role === 'button' ? undefined : attributes._role,
-      'data-order': attributes._order
+      'data-order': attributes._order,
+      'data-tooltip-id': 'pagelevelprogress'
     };
   }
 
@@ -37,6 +39,11 @@ export default class PageLevelProgressNavigationView extends NavigationButtonVie
     this.render();
     this.addIndicator();
     this.deferredUpdate();
+
+    tooltips.register({
+      _id: 'pagelevelprogress',
+      ...Adapt.course.get('_globals')?._extensions?._pageLevelProgress?._navTooltip || {}
+    });
   }
 
   setUpEventListeners() {

--- a/properties.schema
+++ b/properties.schema
@@ -45,6 +45,28 @@
       "inputType": "Text",
       "validators": []
     },
+    "_navTooltip": {
+      "type": "object",
+      "title": "Page Level Progress navigation tooltip",
+      "properties": {
+        "_isEnabled": {
+          "type": "boolean",
+          "default": true,
+          "title": "Enable tooltip for navigation button",
+          "inputType": "Checkbox",
+          "validators": []
+        },
+        "text": {
+          "type": "string",
+          "title": "",
+          "default": "Page progress",
+          "help": "The tooltip text to display on hover over this item",
+          "inputType": "Text",
+          "validators": [],
+          "translatable": true
+        }
+      }
+    },
     "_showLabel": {
       "type": "boolean",
       "required": true,

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -59,6 +59,25 @@
                       "description": "Determines the order in which the page level progress is displayed in the navigation bar. Negative numbers (e.g. -100) are left-aligned. Positive numbers (e.g. 100) are right-aligned.",
                       "default": 90
                     },
+                    "_navTooltip": {
+                      "type": "object",
+                      "title": "Page Level Progress navigation tooltip",
+                      "properties": {
+                        "_isEnabled": {
+                          "type": "boolean",
+                          "title": "Enable tooltip for navigation button",
+                          "default": true
+                        },
+                        "text": {
+                          "type": "string",
+                          "title": "",
+                          "default": "Page progress",
+                          "_adapt": {
+                            "translatable": true
+                          }
+                        }
+                      }
+                    },
                     "_showLabel": {
                       "type": "boolean",
                       "title": "Enable navigation bar button label",


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/issues/186

For consistency with core navigation buttons when tooltips are enabled. Ref: https://github.com/adaptlearning/adapt-contrib-core/pull/207

## Testing the PR
You need to enable Adapt tooltips in _course.json_:
```
  "_tooltips": {
    "_isEnabled": true
  }
```

And use the following config to enable the PageLevelProgress tooltip in _course.json_ (nesting within `_globals` `_extensions`):
```
      "_pageLevelProgress": {
        "_navTooltip": {
          "_isEnabled": true,
          "text": "Page progress"
        }
      }
```