### PR TITLE
New: Separate .is-locked and .is-disabled btn state classes

### DIFF
--- a/js/PageLevelProgressView.js
+++ b/js/PageLevelProgressView.js
@@ -30,7 +30,7 @@ export default class PageLevelProgressView extends Backbone.View {
     if (event && event.preventDefault) event.preventDefault();
 
     const $target = $(event.currentTarget);
-    if ($target.is('.is-disabled')) return;
+    if ($target.is('.is-locked') || $target.is('.is-disabled')) return;
 
     const id = $target.attr('data-pagelevelprogress-id');
     const model = data.findById(id);

--- a/js/PageLevelProgressView.js
+++ b/js/PageLevelProgressView.js
@@ -30,7 +30,7 @@ export default class PageLevelProgressView extends Backbone.View {
     if (event && event.preventDefault) event.preventDefault();
 
     const $target = $(event.currentTarget);
-    if ($target.is('.is-locked') || $target.is('.is-disabled')) return;
+    if ($target.is('.is-disabled')) return;
 
     const id = $target.attr('data-pagelevelprogress-id');
     const model = data.findById(id);

--- a/templates/pageLevelProgressItem.jsx
+++ b/templates/pageLevelProgressItem.jsx
@@ -44,7 +44,7 @@ export default function PageLevelProgressItem(props) {
           'pagelevelprogress__item-btn drawer__item-btn',
           'js-indicator js-pagelevelprogress-item-click',
           (_isLocked) && 'is-locked',
-          (!_isVisible) && 'is-disabled'
+          (_isLocked || !_isVisible) && 'is-disabled'
         ])}
         ref={indicatorSeat}
         data-pagelevelprogress-id={_id}

--- a/templates/pageLevelProgressItem.jsx
+++ b/templates/pageLevelProgressItem.jsx
@@ -43,7 +43,8 @@ export default function PageLevelProgressItem(props) {
         className={classes([
           'pagelevelprogress__item-btn drawer__item-btn',
           'js-indicator js-pagelevelprogress-item-click',
-          (_isLocked || !_isVisible) && 'is-disabled'
+          (_isLocked) && 'is-locked',
+          (!_isVisible) && 'is-disabled'
         ])}
         ref={indicatorSeat}
         data-pagelevelprogress-id={_id}


### PR DESCRIPTION
Relates to Core issue to [allow for locked and inactive disabled buttons to be visually different](https://github.com/adaptlearning/adapt-contrib-core/issues/485).

Depending on the button context, the appropriate `.is-locked` or `.is-disabled` classes should be used.

`.is-locked` - applies to buttons that are temporarily disabled due to step locked content.

`.is-disabled` - applies to buttons with functionality not available. Styles are inherited from Vanilla [less/core/drawerItem.less](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/1354de838956523d0463dcf7ee409b9b6261f7dd/less/core/drawerItem.less#L16). 

~~#### Dependencies
`.is-locked` styles require Vanilla PR, [add drawer item locked state](https://github.com/adaptlearning/adapt-contrib-vanilla/pull/488/files).~~
**Update: Dependency removed** in [6dbfcad](https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/pull/202/commits/6dbfcad448e83c8b59c2d928b4fecd801a2625c3).
After discussion, instead of separating state classes, `.is-locked` has been added in addition to `.is-disabled`. This removes the dependency from Vanilla PR, [add drawer item locked state](https://github.com/adaptlearning/adapt-contrib-vanilla/pull/488/files) as earlier versions of Vanilla will still inherit `.is-disabled` styles.

#### Testing PR example
In your course, navigate to _Adapt Assessment_. Open PLP drawer and inspect. Trickled items, `.pagelevelprogress__item-btn` should have the classes `.is-disabled .is-locked`.

In the same course, set a component to `"_isVisible": false,`. Navigate to this component, open PLP drawer and inspect. The hidden component, `.pagelevelprogress__item-btn` should have the class `.is-disabled`.