### PR TITLE
Fix: Add is-optional and is-complete classes to each PLP item (fixes #203)

### DIFF
--- a/templates/pageLevelProgressItem.jsx
+++ b/templates/pageLevelProgressItem.jsx
@@ -43,6 +43,8 @@ export default function PageLevelProgressItem(props) {
         className={classes([
           'pagelevelprogress__item-btn drawer__item-btn',
           'js-indicator js-pagelevelprogress-item-click',
+          (_isComplete) && 'is-complete',
+          (_isOptional) && 'is-optional',
           (_isLocked) && 'is-locked',
           (_isLocked || !_isVisible) && 'is-disabled'
         ])}


### PR DESCRIPTION
Fix #203 

### Fix
* Adds `is-optional` and `is-complete` classes to each page level progress item

### Testing
1. Set a component to optional with `"_isOptional": true`
2. Complete a different component
3. Check that the new classes are applied to the appropriate `pagelevelprogress__item-btn` element.
