### PR TITLE
Update: display padlock for locked items (fixes #209)

### DIFF
--- a/less/pageLevelProgress.less
+++ b/less/pageLevelProgress.less
@@ -14,7 +14,7 @@
   &__item-btn {
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: space-between;
   }
 
   &__item-title {
@@ -22,7 +22,7 @@
   }
 
   &__indicator {
-    margin: 0 calc(~'12.5% - 1rem');
+    margin-inline-start: calc(~'25% - 1rem');
   }
 
   &__item-btn:not(.is-locked) .pagelevelprogress__item-icon {
@@ -31,6 +31,10 @@
 
   &__item-btn.is-locked .pagelevelprogress__item-icon .icon {
     .icon-padlock-locked;
+  }
+
+  &__item-btn.is-locked .pagelevelprogress__indicator {
+    display: none;
   }
 
   &__item-optional {

--- a/less/pageLevelProgress.less
+++ b/less/pageLevelProgress.less
@@ -25,6 +25,10 @@
     margin: 0 calc(~'12.5% - 1rem');
   }
 
+  &__item-icon .icon {
+    .icon-padlock-locked;
+  }
+
   &__item-optional {
     width: 5rem;
   }

--- a/less/pageLevelProgress.less
+++ b/less/pageLevelProgress.less
@@ -25,7 +25,11 @@
     margin: 0 calc(~'12.5% - 1rem');
   }
 
-  &__item-icon .icon {
+  &__item-btn:not(.is-locked) .pagelevelprogress__item-icon {
+    display: none;
+  }
+
+  &__item-btn.is-locked .pagelevelprogress__item-icon .icon {
     .icon-padlock-locked;
   }
 

--- a/templates/pageLevelProgressItem.jsx
+++ b/templates/pageLevelProgressItem.jsx
@@ -64,6 +64,12 @@ export default function PageLevelProgressItem(props) {
           </span>
         </span>
 
+        {_isLocked &&
+        <span className='pagelevelprogress__item-icon'>
+          <span className='icon' aria-hidden="true"></span>
+        </span>
+        }
+        
         {_isOptional &&
         <span className="pagelevelprogress__item-optional">
           <span className="pagelevelprogress__item-optional-inner">

--- a/templates/pageLevelProgressItem.jsx
+++ b/templates/pageLevelProgressItem.jsx
@@ -64,10 +64,6 @@ export default function PageLevelProgressItem(props) {
           </span>
         </span>
 
-        <span className='pagelevelprogress__item-icon'>
-          <span className='icon' aria-hidden="true"></span>
-        </span>
-
         {_isOptional &&
         <span className="pagelevelprogress__item-optional">
           <span className="pagelevelprogress__item-optional-inner">
@@ -75,6 +71,10 @@ export default function PageLevelProgressItem(props) {
           </span>
         </span>
         }
+
+        <span className='pagelevelprogress__item-icon'>
+          <span className='icon' aria-hidden="true"></span>
+        </span>
 
       </button>
       <div className='pagelevelprogress__item-children'>

--- a/templates/pageLevelProgressItem.jsx
+++ b/templates/pageLevelProgressItem.jsx
@@ -64,12 +64,10 @@ export default function PageLevelProgressItem(props) {
           </span>
         </span>
 
-        {_isLocked &&
         <span className='pagelevelprogress__item-icon'>
           <span className='icon' aria-hidden="true"></span>
         </span>
-        }
-        
+
         {_isOptional &&
         <span className="pagelevelprogress__item-optional">
           <span className="pagelevelprogress__item-optional-inner">


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/issues/209

### Update
As per https://github.com/adaptlearning/adapt-contrib-vanilla/issues/446, locked buttons should display a padlock icon.

I considered whether the padlock icon should replace the progress indicator when locked but for now decided to keep this as supplementary. 

<img width="319" alt="locked_plp_buttons" src="https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/assets/7045330/69bd7017-3933-44e2-85db-57b9b52efc16">
<br><br>
Note, the addition of `.pagelevelprogress__item-icon` could be later used to replace progress bars with icons as per #181.



