### PR TITLE
Fix: Only show relevant child sub contentobjects (fixes #211)

### DIFF
--- a/js/getPageLevelProgressItems.js
+++ b/js/getPageLevelProgressItems.js
@@ -15,6 +15,9 @@ export default function getPageLevelProgressItemsJSON(parentModel) {
       const isDescendantCurrentPage = (model === parentModel);
       if (!isInAPage && !isDescendantContentObject) return false;
       if (isInAPage && !isDescendantCurrentPage && !isDescendantContentObject) return false;
+      const descendantParentModel = descendant.getParent();
+      const isChildOfModel = (descendantParentModel === model);
+      if (isDescendantContentObject && !isChildOfModel) return false;
       return (descendant.get('_isAvailable') === true);
     });
     const availableItems = completionCalculations.filterAvailableChildren(currentPageItems);


### PR DESCRIPTION
fixes #211 

### Fix
* Prevent all descendant sub contentobject appearing when _showAtCourseLevel: true and only show relevant contentobjects at each level

### Testing
* Using vanilla course, enable course.json:_pageLevelProgress._showAtCourseLevel
* Add content object
```json
  {
    "_id": "co-1",
    "_parentId": "course",
    "_type": "menu",
    "_classes": "",
    "_htmlClasses": "",
    "title": "Container",
    "displayTitle": "Container",
    "body": "Find out what presentation components are available within the core bundle and how you might consider using them within your courses.",
    "pageBody": "",
    "instruction": "Scroll down to see what presentation components are available as part of the v5 core bundle.",
    "_graphic": {
      "src": "course/en/images/menu-item.png",
      "alt": ""
    },
    "linkText": "View",
    "duration": "2 mins",
    "_pageLevelProgress": {
      "_isEnabled": true,
      "_showPageCompletion": false,
      "_excludeAssessments": false,
      "_isCompletionIndicatorEnabled": false
    }
  },
```
* Change `_parentId` of other content objects to `"co-1"`
* Switch to this branch of plp
* Compile

![image](https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/assets/7974663/a8bfafa0-4eb2-441b-8464-d4b264d21703)
![image](https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/assets/7974663/78d30b00-c87b-41f1-9f8d-8b69d4753b01)
