### PR TITLE
New: add model type selector to drawer item button (fixes #185)

### DIFF
--- a/templates/pageLevelProgressItem.jsx
+++ b/templates/pageLevelProgressItem.jsx
@@ -44,6 +44,7 @@ export default function PageLevelProgressItem(props) {
         className={classes([
           'pagelevelprogress__item-btn drawer__item-btn',
           'js-indicator js-pagelevelprogress-item-click',
+          `is-${_type}-indicator`,
           (_isComplete) && 'is-complete',
           (_isOptional) && 'is-optional',
           (_isLocked) && 'is-locked',


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/issues/185

### New
Model `_type` selector added to `.pagelevelprogress__item-btn`. This allows for more flexibility when styling nested PLP drawer items. 

Selectors include:

Course/Main menu: `.is-course-indicator`
Page: `.is-page-indicator`
Sub menu: `.is-menu-indicator`
Component: `.is-component-indicator`


