### PR TITLE
Fix: Replace deprecated drawer.triggerCustomView with drawer.openCustomView (fixes #222)

### DIFF
--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -91,7 +91,7 @@ export default class PageLevelProgressNavigationView extends NavigationButtonVie
   onProgressClicked(event) {
     if (event && event.preventDefault) event.preventDefault();
     this.$el.attr('aria-expanded', true);
-    drawer.triggerCustomView(new PageLevelProgressView({
+    drawer.openCustomView(new PageLevelProgressView({
       collection: this.collection
     }).$el, false, this.model.get('_drawerPosition'));
   }


### PR DESCRIPTION
Fix #222 

### Fix
* Replaces deprecated `drawer.triggerCustomView` with `drawer.openCustomView`
