### PR TITLE
New: Add option to show course-level progress on PLP nav button (fix #226)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Add to _course.json_.
 
 > **\_showAtCourseLevel** (boolean): Allows **Page Level Progress** to display all content objects and the current page components together, or just the current page components as before. Acceptable values are `true` and `false`. Defaults to `false`.
 
-> **\_showAtCourseLevelInNavigationBar** (boolean): Allows **Page Level Progress** to use course-level completion for the navigation button instead of page-level completion. Defaults to `false`.
+> **\_useCourseProgressInNavigationButton** (boolean): Allows **Page Level Progress** to use course-level completion for the navigation button instead of page-level completion. Defaults to `false`.
 
 Add to _contentObjects.json_.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ Add to _course.json_.
 
 > **\_showPageCompletion** (boolean): Set to `false` to have the overall progress calculated only from components that have been set to display in **Page Level Progress** (ignoring the completion of those that haven't). Defaults to `true`.
 
-> **\_showAtCourseLevel** (boolean): Allows **Page Level Progress** to display all content objects and the current page components together, or just the current page components as before. Acceptable values are `true` and `false`.
+> **\_showAtCourseLevel** (boolean): Allows **Page Level Progress** to display all content objects and the current page components together, or just the current page components as before. Acceptable values are `true` and `false`. Defaults to `false`.
+
+> **\_showAtCourseLevelInNavigationBar** (boolean): Allows **Page Level Progress** to use course-level completion for the navigation button instead of page-level completion. Defaults to `false`.
 
 Add to _contentObjects.json_.
 

--- a/example.json
+++ b/example.json
@@ -20,7 +20,8 @@
         "_showPageCompletion": true,
         "_isCompletionIndicatorEnabled": true,
         "_isShownInNavigationBar": true,
-        "_showAtCourseLevel": false
+        "_showAtCourseLevel": false,
+        "_showAtCourseLevelInNavigationBar": false
     }
 
     // To go on a contentObject

--- a/example.json
+++ b/example.json
@@ -21,7 +21,7 @@
         "_isCompletionIndicatorEnabled": true,
         "_isShownInNavigationBar": true,
         "_showAtCourseLevel": false,
-        "_showAtCourseLevelInNavigationBar": false
+        "_useCourseProgressInNavigationButton": false
     }
 
     // To go on a contentObject

--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -69,9 +69,8 @@ export default class PageLevelProgressNavigationView extends NavigationButtonVie
 
   _getPageCompletionPercentage() {
     const courseConfig = Adapt.course.get('_pageLevelProgress');
-    const useCourseLevel = courseConfig._showAtCourseLevel && courseConfig._showAtCourseLevelInNavigationBar;
 
-    if (useCourseLevel) {
+    if (courseConfig._showAtCourseLevelInNavigationBar) {
       return completionCalculations.calculatePercentageComplete(Adapt.course);
     }
 

--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -68,6 +68,13 @@ export default class PageLevelProgressNavigationView extends NavigationButtonVie
   }
 
   _getPageCompletionPercentage() {
+    const courseConfig = Adapt.course.get('_pageLevelProgress');
+    const useCourseLevel = courseConfig._showAtCourseLevel && courseConfig._showAtCourseLevelInNavigationBar;
+
+    if (useCourseLevel) {
+      return completionCalculations.calculatePercentageComplete(Adapt.course);
+    }
+
     return completionCalculations.calculatePercentageComplete(this.pageModel, true);
   }
 

--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -70,7 +70,7 @@ export default class PageLevelProgressNavigationView extends NavigationButtonVie
   _getPageCompletionPercentage() {
     const courseConfig = Adapt.course.get('_pageLevelProgress');
 
-    if (courseConfig._showAtCourseLevelInNavigationBar) {
+    if (courseConfig._useCourseProgressInNavigationButton) {
       return completionCalculations.calculatePercentageComplete(Adapt.course);
     }
 

--- a/properties.schema
+++ b/properties.schema
@@ -173,7 +173,7 @@
                   "validators": [],
                   "help": "Controls whether to display all content objects and the current page components together, or just the current page components."
                 },
-                "_showAtCourseLevelInNavigationBar": {
+                "_useCourseProgressInNavigationButton": {
                   "type": "boolean",
                   "required": true,
                   "default": false,

--- a/properties.schema
+++ b/properties.schema
@@ -172,6 +172,15 @@
                   "inputType": "Checkbox",
                   "validators": [],
                   "help": "Controls whether to display all content objects and the current page components together, or just the current page components."
+                },
+                "_showAtCourseLevelInNavigationBar": {
+                  "type": "boolean",
+                  "required": true,
+                  "default": false,
+                  "title": "Use course-level progress on navigation button",
+                  "inputType": "Checkbox",
+                  "validators": [],
+                  "help": "When enabled, the navigation button will show course-level progress rather than page-level progress. Defaults to disabled."
                 }
               }
             }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -148,6 +148,12 @@
               "title": "Display all content objects and the current page components",
               "description": "Controls whether to display all content objects and the current page components together, or just the current page components",
               "default": false
+            },
+            "_showAtCourseLevelInNavigationBar": {
+              "type": "boolean",
+              "title": "Use course-level progress on navigation button",
+              "description": "When enabled, the navigation button will show course-level progress rather than page-level progress. Defaults to disabled.",
+              "default": false
             }
           }
         }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -149,7 +149,7 @@
               "description": "Controls whether to display all content objects and the current page components together, or just the current page components",
               "default": false
             },
-            "_showAtCourseLevelInNavigationBar": {
+            "_useCourseProgressInNavigationButton": {
               "type": "boolean",
               "title": "Use course-level progress on navigation button",
               "description": "When enabled, the navigation button will show course-level progress rather than page-level progress. Defaults to disabled.",


### PR DESCRIPTION
Fixes #226 

### New
* Adds the `_useCourseProgressInNavigationButton` option to show course-level progress on the PLP nav button instead of page-level progress.

### Testing
1. In _course.json_, set `_pageLevelProgress._useCourseProgressInNavigationButton` to `true`.
2. Go to a page and complete it, but leave other pages incomplete.

### Expected result
The PLP button in the navigation should show as partially completed since only one page is complete.