### PR TITLE
Fix: Return correct calculation for presentation components with items (fixes #228)

### DIFF
--- a/js/PageLevelProgressIndicatorView.js
+++ b/js/PageLevelProgressIndicatorView.js
@@ -53,12 +53,14 @@ class PageLevelProgressIndicatorView extends Backbone.View {
 
   calculatePercentage() {
     const isPresentationComponentWithItems = (!this.model.isTypeGroup('question') && this.model instanceof ItemsComponentModel);
+    const isComplete = this.model.get('_isComplete');
     if (isPresentationComponentWithItems) {
+      if (isComplete) return 100;
       const children = this.model.getChildren();
       const visited = children.filter(child => child.get('_isVisited'));
       return Math.round(visited.length / children.length * 100);
     }
-    return this.model.get('_isComplete') ? 100 : 0;
+    return isComplete ? 100 : 0;
   }
 
   render() {

--- a/js/PageLevelProgressIndicatorView.js
+++ b/js/PageLevelProgressIndicatorView.js
@@ -56,7 +56,6 @@ class PageLevelProgressIndicatorView extends Backbone.View {
     const isComplete = this.model.get('_isComplete');
     if (isComplete) return 100;
     if (isPresentationComponentWithItems) {
-      if (isComplete) return 100;
       const children = this.model.getChildren();
       const visited = children.filter(child => child.get('_isVisited'));
       return Math.round(visited.length / children.length * 100);

--- a/js/PageLevelProgressIndicatorView.js
+++ b/js/PageLevelProgressIndicatorView.js
@@ -60,7 +60,7 @@ class PageLevelProgressIndicatorView extends Backbone.View {
       const visited = children.filter(child => child.get('_isVisited'));
       return Math.round(visited.length / children.length * 100);
     }
-    return isComplete ? 100 : 0;
+    return 0
   }
 
   render() {

--- a/js/PageLevelProgressIndicatorView.js
+++ b/js/PageLevelProgressIndicatorView.js
@@ -54,6 +54,7 @@ class PageLevelProgressIndicatorView extends Backbone.View {
   calculatePercentage() {
     const isPresentationComponentWithItems = (!this.model.isTypeGroup('question') && this.model instanceof ItemsComponentModel);
     const isComplete = this.model.get('_isComplete');
+    if (isComplete) return 100;
     if (isPresentationComponentWithItems) {
       if (isComplete) return 100;
       const children = this.model.getChildren();


### PR DESCRIPTION
Fix #228 

### Fix
* Correctly calculates completion percentage when making presentation components with items complete.

### Testing
1. Install [Dev Tools](https://github.com/cgkineo/adapt-devtools/).
2. Visit a page that contains presentation components with items (e.g. Narrative, Accordion)
3. Click "Complete page" in Dev Tools
4. Alternatively, use similar [functionality](https://github.com/cgkineo/adapt-devtools/blob/ffd7369163c8e070060b78a08f23fa5c95144165/js/adapt-devtools.js#L285) to complete all components on the page.

### Expected result
Presentation components with items should show as 100% completed in the PLP drawer.