### PR TITLE
Fix: Content object progress calculations (fixes #233)

### DIFF
--- a/js/PageLevelProgressIndicatorView.js
+++ b/js/PageLevelProgressIndicatorView.js
@@ -49,12 +49,10 @@ class PageLevelProgressIndicatorView extends Backbone.View {
   }
 
   calculatePercentage() {
+    const isContentObject = this.model.isTypeGroup('contentobject');
+    if (isContentObject) return completionCalculations.calculatePercentageComplete(this.model);
     const isComplete = this.model.get('_isComplete');
     if (isComplete) return 100;
-    const isContentObject = this.model.isTypeGroup('contentobject');
-    if (isContentObject) {
-      return completionCalculations.calculatePercentageComplete(this.model);
-    }
     const isPresentationComponentWithItems = (!this.model.isTypeGroup('question') && this.model instanceof ItemsComponentModel);
     if (isPresentationComponentWithItems) {
       const children = this.model.getChildren();


### PR DESCRIPTION
fixes #233 

### Fix
* Defer to `calculatePercentageComplete` for content objects always


