### PR TITLE
Fix: Fix lock icon alignment (fix #237)

### DIFF
--- a/less/pageLevelProgress.less
+++ b/less/pageLevelProgress.less
@@ -25,6 +25,10 @@
     margin-inline-start: calc(~'25% - 1rem');
   }
 
+  &__item-btn.is-locked .pagelevelprogress__item-icon {
+    margin-inline-start: auto;
+  }
+
   &__item-btn:not(.is-locked) .pagelevelprogress__item-icon {
     display: none;
   }


### PR DESCRIPTION
Fixes #237 

### Fix
* Fixes the lock icon alignment so that it better aligns with the progress bars in other items

### Testing
1. Lock some blocks with Trickle.
2. Open the PLP drawer.

### Expected results
<img width="367" alt="Screenshot 2024-09-25 at 1 12 47 PM" src="https://github.com/user-attachments/assets/251129c3-10aa-43f3-9d76-a6b80d2ca7b5">
