### PR TITLE
Fix: Make contentObject:_pageLevelProgress._isEnabled atomic on nested submenus (fixes #247)

### DIFF
--- a/js/getPageLevelProgressItems.js
+++ b/js/getPageLevelProgressItems.js
@@ -18,7 +18,7 @@ export default function getPageLevelProgressItemsJSON(parentModel) {
       const descendantParentModel = descendant.getParent();
       const isParentModelShown = Boolean(descendantParentModel.get('_pageLevelProgress')?._isEnabled);
       const isChildOfModel = (descendantParentModel === model);
-      if (isDescendantContentObject && (isParentModelShown && !isChildOfModel)) return false;
+      if (isDescendantContentObject && isParentModelShown && !isChildOfModel) return false;
       return (descendant.get('_isAvailable') === true);
     });
     const availableItems = completionCalculations.filterAvailableChildren(currentPageItems);

--- a/js/getPageLevelProgressItems.js
+++ b/js/getPageLevelProgressItems.js
@@ -16,8 +16,9 @@ export default function getPageLevelProgressItemsJSON(parentModel) {
       if (!isInAPage && !isDescendantContentObject) return false;
       if (isInAPage && !isDescendantCurrentPage && !isDescendantContentObject) return false;
       const descendantParentModel = descendant.getParent();
+      const isParentModelShown = Boolean(descendantParentModel.get('_pageLevelProgress')?._isEnabled);
       const isChildOfModel = (descendantParentModel === model);
-      if (isDescendantContentObject && !isChildOfModel) return false;
+      if (isDescendantContentObject && (isParentModelShown && !isChildOfModel)) return false;
       return (descendant.get('_isAvailable') === true);
     });
     const availableItems = completionCalculations.filterAvailableChildren(currentPageItems);


### PR DESCRIPTION
fixes #247 

alternative to https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/pull/248

### Fix
* All descendant pages will be shown, when configured with `_pageLevelProgress: true`, they will be shown nested if their parent has `_pageLevelProgress: true` or at the current level if their parent is `_pageLevelProgress: false`
