### PR TITLE
Update: Replace dialog button aria-expanded with aria-haspopup dialog (fixes #250)

### DIFF
--- a/js/PageLevelProgressNavigationView.js
+++ b/js/PageLevelProgressNavigationView.js
@@ -23,7 +23,7 @@ export default class PageLevelProgressNavigationView extends NavigationButtonVie
       role: attributes._role === 'button' ? undefined : attributes._role,
       'data-order': attributes._order,
       'data-tooltip-id': 'pagelevelprogress',
-      'aria-expanded': false
+      'aria-haspopup': 'dialog'
     };
   }
 
@@ -53,8 +53,7 @@ export default class PageLevelProgressNavigationView extends NavigationButtonVie
     this.listenTo(Adapt, {
       remove: this.remove,
       'router:location': this.updateProgressBar,
-      'view:childAdded pageLevelProgress:update': this.refreshProgressBar,
-      'drawer:closed': this.drawerClosed
+      'view:childAdded pageLevelProgress:update': this.refreshProgressBar
     });
     this.listenTo(data, 'change:_isLocked change:_isVisible change:_isComplete', this.refreshProgressBar);
   }
@@ -99,13 +98,8 @@ export default class PageLevelProgressNavigationView extends NavigationButtonVie
     this.updateProgressBar();
   }
 
-  drawerClosed() {
-    this.$el.attr('aria-expanded', false);
-  }
-
   onProgressClicked(event) {
     if (event && event.preventDefault) event.preventDefault();
-    this.$el.attr('aria-expanded', true);
     drawer.openCustomView(new PageLevelProgressView({
       collection: this.collection
     }).$el, false, this.model.get('_drawerPosition'));


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/issues/250

### Update
The navigation button that triggers a dialog to open (Drawer), the button `aria-expanded` has been replaced with `aria-haspopup="dialog"`.  Please refer to the [issue](https://github.com/adaptlearning/adapt-contrib-core/issues/657) for the research and discussion supporting this change.

### Testing
Navigate to the PLP button in the nav bar using a screen reader. Depending on the browser/screen reader used, expect the following reading....

VoiceOver “Page progress. X%. Open page sections, dialog pop-up, button”
NVDA “Page progress. X%. Open page sections, button opens dialog”
JAWS “Page progress. X%. Open page sections, button has popup dialog”

Tested with the following combinations:
VoiceOver Safari macOS and iPhone
VoiceOver Chrome and Firefox macOS
JAWS Chrome, Edge and Firefox Windows
NVDA Chrome, Edge and Firefox Windows




