### PR TITLE
Fix: Add optional content visual indicator (fix #259)

### DIFF
--- a/js/PageLevelProgressIndicatorView.js
+++ b/js/PageLevelProgressIndicatorView.js
@@ -99,14 +99,7 @@ class PageLevelProgressIndicatorView extends Backbone.View {
     const data = this.model.toJSON();
     data.ariaLabel = this.ariaLabel;
     data.type = this.type;
-
-    // Check if content is optional (set by diagnostic extension)
     data._isOptional = this.model.get('_isOptional') || false;
-
-    // Note: do not generate a combined screen-reader string here. Visible labels
-    // will remain present and any aria labeling should be handled by the template
-    // or higher-level components to avoid duplicating responsibilities.
-
     return data;
   }
 

--- a/js/PageLevelProgressIndicatorView.js
+++ b/js/PageLevelProgressIndicatorView.js
@@ -99,6 +99,7 @@ class PageLevelProgressIndicatorView extends Backbone.View {
     const data = this.model.toJSON();
     data.ariaLabel = this.ariaLabel;
     data.type = this.type;
+    data._globals = Adapt.course.get('_globals');
     data._isOptional = this.model.get('_isOptional') || false;
     return data;
   }

--- a/js/PageLevelProgressIndicatorView.js
+++ b/js/PageLevelProgressIndicatorView.js
@@ -57,7 +57,8 @@ class PageLevelProgressIndicatorView extends Backbone.View {
     if (isPresentationComponentWithItems) {
       const children = this.model.getChildren();
       const visited = children.filter(child => child.get('_isVisited'));
-      return Math.round(visited.length / children.length * 100);
+      // Handle division by zero when component has no children
+      return children.length === 0 ? 0 : Math.round(visited.length / children.length * 100);
     }
     return 0;
   }
@@ -98,6 +99,14 @@ class PageLevelProgressIndicatorView extends Backbone.View {
     const data = this.model.toJSON();
     data.ariaLabel = this.ariaLabel;
     data.type = this.type;
+
+    // Check if content is optional (set by diagnostic extension)
+    data._isOptional = this.model.get('_isOptional') || false;
+
+    // Note: do not generate a combined screen-reader string here. Visible labels
+    // will remain present and any aria labeling should be handled by the template
+    // or higher-level components to avoid duplicating responsibilities.
+
     return data;
   }
 

--- a/js/completionCalculations.js
+++ b/js/completionCalculations.js
@@ -132,7 +132,8 @@ class Completion extends Backbone.Controller {
     // this allows the user to see if assessments have been passed, if assessment components can be retaken, and all other component's completion
     const completed = completionObject.nonAssessmentCompleted + completionObject.assessmentCompleted + completionObject.subProgressCompleted;
     const total = completionObject.nonAssessmentTotal + completionObject.assessmentTotal + completionObject.subProgressTotal;
-    const percentageComplete = Math.floor((completed / total) * 100);
+    // Handle division by zero when page contains only optional content
+    const percentageComplete = total === 0 ? 0 : Math.floor((completed / total) * 100);
     return percentageComplete;
   }
 

--- a/less/pageLevelProgressIndicator.less
+++ b/less/pageLevelProgressIndicator.less
@@ -1,6 +1,53 @@
 // Global indicator
 // --------------------------------------------------
 .pagelevelprogress {
+  &__indicator-outer {
+    display: flex;
+    flex-direction: column;
+    /* left-align the group within the outer container */
+    align-items: flex-start;
+  }
+
+  &__indicator-group {
+    display: flex;
+    flex-direction: column;
+    /* center the indicator and label horizontally as a group */
+    align-items: center;
+  }
+
+  // Override core .aria-label (which is visually-hidden) for our
+  // indicator group so the message can be presented visually and
+  // styled similar to a header/title. Keep it lightweight.
+  &__indicator-group .aria-label {
+    position: static;
+    display: block;
+    width: auto;
+    height: auto;
+    margin: 0;
+    padding: 0;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+    pointer-events: none;
+    font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1.1;
+    color: @black;
+  }
+
+  /* Screen-reader-only text (accessible but not visible) */
+  .sr-only {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+  }
+
   &__indicator {
     display: flex;
     width: 2rem;
@@ -26,6 +73,15 @@
     min-width: 15%;
     background-color: @black;
     width: var(--adapt-pagelevelprogress-percentage);
+  }
+
+  &__indicator-label {
+    font-size: 0.5rem;
+    font-weight: normal;
+    text-align: center;
+    margin-top: 0.125rem;
+    line-height: 1;
+    white-space: nowrap;
   }
 
   &__indicator .js-indicator-aria-label {

--- a/less/pageLevelProgressIndicator.less
+++ b/less/pageLevelProgressIndicator.less
@@ -4,48 +4,13 @@
   &__indicator-outer {
     display: flex;
     flex-direction: column;
-    /* left-align the group within the outer container */
     align-items: flex-start;
   }
 
   &__indicator-group {
     display: flex;
     flex-direction: column;
-    /* center the indicator and label horizontally as a group */
     align-items: center;
-  }
-
-  // Override core .aria-label (which is visually-hidden) for our
-  // indicator group so the message can be presented visually and
-  // styled similar to a header/title. Keep it lightweight.
-  &__indicator-group .aria-label {
-    position: static;
-    display: block;
-    width: auto;
-    height: auto;
-    margin: 0;
-    padding: 0;
-    overflow: visible;
-    clip: auto;
-    white-space: normal;
-    pointer-events: none;
-    font-size: 0.875rem;
-    font-weight: 600;
-    line-height: 1.1;
-    color: @black;
-  }
-
-  /* Screen-reader-only text (accessible but not visible) */
-  .sr-only {
-    position: absolute !important;
-    width: 1px !important;
-    height: 1px !important;
-    padding: 0 !important;
-    margin: -1px !important;
-    overflow: hidden !important;
-    clip: rect(0, 0, 0, 0) !important;
-    white-space: nowrap !important;
-    border: 0 !important;
   }
 
   &__indicator {
@@ -82,9 +47,5 @@
     margin-top: 0.125rem;
     line-height: 1;
     white-space: nowrap;
-  }
-
-  &__indicator .js-indicator-aria-label {
-    top: 0;
   }
 }

--- a/templates/pageLevelProgressIndicator.jsx
+++ b/templates/pageLevelProgressIndicator.jsx
@@ -3,22 +3,35 @@ import { compile } from 'core/js/reactHelpers';
 
 export default function PageLevelProgressIndicator (props) {
   const {
-    ariaLabel
+    ariaLabel,
+    _isOptional
   } = props;
 
+  // Build aria-label with optional prefix if needed
+  const compiledAriaLabel = ariaLabel ? compile(ariaLabel, props) : '';
+  const fullAriaLabel = _isOptional ? `Optional. ${compiledAriaLabel}` : compiledAriaLabel;
+
   return (
-    <span className='pagelevelprogress__indicator'>
-      <span className="pagelevelprogress__indicator-inner">
+    <React.Fragment>
+      <span className='pagelevelprogress__indicator'>
+        <span className="pagelevelprogress__indicator-inner">
 
-        <span className="pagelevelprogress__indicator-bar"></span>
+          <span className="pagelevelprogress__indicator-bar"></span>
 
-        {ariaLabel &&
-        <span className="aria-label">
-          {compile(ariaLabel, props)}
+          {ariaLabel &&
+          <span className="aria-label">
+            {fullAriaLabel}
+          </span>
+          }
+
         </span>
-        }
-
       </span>
-    </span>
+
+      {_isOptional &&
+      <span className="pagelevelprogress__indicator-label" aria-hidden="true">
+        Optional
+      </span>
+      }
+    </React.Fragment>
   );
 };

--- a/templates/pageLevelProgressIndicator.jsx
+++ b/templates/pageLevelProgressIndicator.jsx
@@ -9,29 +9,47 @@ export default function PageLevelProgressIndicator (props) {
 
   // Build aria-label with optional prefix if needed
   const compiledAriaLabel = ariaLabel ? compile(ariaLabel, props) : '';
-  const fullAriaLabel = _isOptional ? `Optional. ${compiledAriaLabel}` : compiledAriaLabel;
+  const optionalLabel = props._globals?._accessibility?._ariaLabels?.optional || 'Optional';
+  const fullAriaLabel = _isOptional ? `${optionalLabel}. ${compiledAriaLabel}` : compiledAriaLabel;
 
-  return (
-    <React.Fragment>
-      <span className='pagelevelprogress__indicator'>
-        <span className="pagelevelprogress__indicator-inner">
+  // Only render wrapper group when optional label exists
+  if (_isOptional) {
+    return (
+      <span className='pagelevelprogress__indicator-group'>
+        <span className='pagelevelprogress__indicator'>
+          <span className="pagelevelprogress__indicator-inner">
 
-          <span className="pagelevelprogress__indicator-bar"></span>
+            <span className="pagelevelprogress__indicator-bar"></span>
 
-          {ariaLabel &&
-          <span className="aria-label">
-            {fullAriaLabel}
+            {ariaLabel &&
+            <span className="aria-label">
+              {fullAriaLabel}
+            </span>
+            }
+
           </span>
-          }
+        </span>
 
+        <span className="pagelevelprogress__indicator-label" aria-hidden="true">
+          {optionalLabel}
         </span>
       </span>
+    );
+  }
 
-      {_isOptional &&
-      <span className="pagelevelprogress__indicator-label" aria-hidden="true">
-        Optional
+  return (
+    <span className='pagelevelprogress__indicator'>
+      <span className="pagelevelprogress__indicator-inner">
+
+        <span className="pagelevelprogress__indicator-bar"></span>
+
+        {ariaLabel &&
+        <span className="aria-label">
+          {fullAriaLabel}
+        </span>
+        }
+
       </span>
-      }
-    </React.Fragment>
+    </span>
   );
 };


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
- Fixes #259 
- Fixed division by zero errors in completionCalculations.js when page contains only optional content - now returns 0 instead of NaN
- Fixed division by zero in PageLevelProgressIndicatorView.js when components have no children

### New
- Added visual "Optional" label below progress indicators when isOptional is true.
- Added "Optional." prefix to aria-label for screen reader announcements
- Implemented conditional wrapper rendering when label exists.

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Set `"_isOptional": true` on page content (manually or via diagnostic extension)
2. Navigate to menu and verify:
3. Progress indicator shows "Optional" label below the progress bar
4. Empty progress bar displays correctly (0% instead of appearing full due to NaN)
5. Navigate within the optional page and check the navigation bar progress indicator
6. Test with screen reader - verify it announces "Optional" before progress information
7. Test non-optional content - verify no extra wrapper elements or labels appear
8. Inspect DOM - confirm pagelevelprogress__indicator-group only exists when content is optional

[//]: # (Mention any other dependencies)


