### PR TITLE
Fix: Prevent NaN progress calculations (fixes #259)

### DIFF
--- a/js/PageLevelProgressIndicatorView.js
+++ b/js/PageLevelProgressIndicatorView.js
@@ -57,7 +57,8 @@ class PageLevelProgressIndicatorView extends Backbone.View {
     if (isPresentationComponentWithItems) {
       const children = this.model.getChildren();
       const visited = children.filter(child => child.get('_isVisited'));
-      return Math.round(visited.length / children.length * 100);
+      // Handle division by zero when component has no children
+      return children.length === 0 ? 0 : Math.round(visited.length / children.length * 100);
     }
     return 0;
   }

--- a/js/completionCalculations.js
+++ b/js/completionCalculations.js
@@ -132,7 +132,8 @@ class Completion extends Backbone.Controller {
     // this allows the user to see if assessments have been passed, if assessment components can be retaken, and all other component's completion
     const completed = completionObject.nonAssessmentCompleted + completionObject.assessmentCompleted + completionObject.subProgressCompleted;
     const total = completionObject.nonAssessmentTotal + completionObject.assessmentTotal + completionObject.subProgressTotal;
-    const percentageComplete = Math.floor((completed / total) * 100);
+    // Handle division by zero when page contains only optional content
+    const percentageComplete = total === 0 ? 0 : Math.floor((completed / total) * 100);
     return percentageComplete;
   }
 


### PR DESCRIPTION
### Fix
- Fixes #259 
- Prevent division-by-zero that produced NaN for page-level progress when a page contains only optional content.
- Page-level progress now consistently returns 0 for fully-optional pages/components instead of NaN, preventing invalid CSS such as --adapt-pagelevelprogress-percentage: NaN%; which previously made the indicator render incorrectly.

### Testing
1. Set "_isOptional": true on page content (manually or via diagnostic extension)
2. Navigate to menu and verify:
3. Progress indicator shows "Optional" label below the progress bar
4. Empty progress bar displays correctly (0% instead of appearing full due to NaN)
5. Navigate within the optional page and check the navigation bar progress indicator
6. Test with screen reader - verify it announces "Optional" before progress information
7. Test non-optional content - verify no extra wrapper elements or labels appear
8. Inspect DOM - confirm pagelevelprogress__indicator-group only exists when content is optional